### PR TITLE
Unify the sidebar hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 hrdx is a experimental, minimal and lightweight terminal multiplexer built for the agent era: your projects as workspaces in a sidebar, tabs per workspace, and real terminal panes running [Codex CLI](https://learn.chatgpt.com/docs/codex/cli), [Claude Code](https://code.claude.com/docs/en/quickstart), [pi](https://www.pi.dev), [zot](https://www.zot.sh) or plain shells side by side. Kick off an agent in one project, switch to the next, and let the sidebar spinners tell you who is still working.
 
 - **Real terminals, not wrappers.** Every pane is a genuine PTY session with a full terminal emulator behind it. Agent TUIs run exactly as they do standalone: streaming, slash commands, sessions, mouse support, all of it. Panes present a clean terminal identity so capability-sniffing TUIs pick rendering paths that work inside a multiplexer, and `HRDX=1` lets tools detect they run inside hrdx.
-- **Everything in view.** The sidebar shows every workspace with its git branch and ahead/behind counts, every pane with a live status dot, and an agents list that jumps you straight to any running agent, including ones you started by hand inside a shell.
+- **Everything in view.** The sidebar shows one hierarchy of workspaces, Git branches, and panes, adding tab rows only when a workspace has multiple tabs. Shell circles and agent diamonds expose pane type and state at a glance; an agent's icon becomes an animated braille spinner while it works.
 - **Feels like your terminal.** Scrollback, mouse selection with clipboard copy, drag-to-resize splits, drag-to-reorder workspaces, right-click context menus, and kitty keyboard protocol pass-through so even exotic chords like ctrl+1 reach your agent.
 - **Picks up where you left off.** Quit and relaunch: shells and agents keep running in a lightweight session holder and reattach exactly where they were, running commands and all. Workspaces, tabs, splits, and ratios come back too, and if a session is truly gone, agents resume their latest conversation from their own session store.
 - **Yours to tune.** A settings window (`ctrl+b ,` or the gear in the sidebar) lets you switch individual agents on or off, pick a notification sound for finished turns (including your own audio files), and change the color theme, with user themes as simple JSON files. All persisted. See [Themes](#themes).
@@ -116,7 +116,7 @@ Actions: `prefix`, `literal`, `quit`, `picker-right`, `picker-down`, `agent-righ
 
 ## Mouse
 
-Everything is clickable: tabs, workspaces, panes, agents, menus, and the settings entry at the bottom of the sidebar. Drag workspaces to reorder them, drag pane borders to resize, right-click for context menus, and drag with the left button to select text (copied straight to your clipboard). Wheel events go to the pane under the cursor: agent TUIs scroll themselves, shells scroll their local history, and `shift+pgup` / `shift+pgdn` do the same from the keyboard.
+Everything is clickable: workspace, tab, and pane rows in the sidebar, the main tab bar, menus, and the settings entry at the bottom. Drag workspaces to reorder them, drag pane borders to resize, right-click for context menus, and drag with the left button to select text (copied straight to your clipboard). Wheel events go to the pane under the cursor: agent TUIs scroll themselves, shells scroll their local history, and `shift+pgup` / `shift+pgdn` do the same from the keyboard.
 
 ## Remote and container panes
 
@@ -166,7 +166,7 @@ The session holder keeps the local SSH, Docker, or Kubernetes client process ali
 
 ## Custom harnesses
 
-Any agent CLI beyond the built-ins can be registered by dropping a `harness.json` next to the state file (`~/Library/Application Support/hrdx/` on macOS, `$XDG_CONFIG_HOME/hrdx/` on Linux, `%AppData%\hrdx\` on Windows). Registered harnesses appear everywhere the built-ins do: in the pickers, in agent cycling, in the sidebar agents list, and in the settings window for enabling and disabling.
+Any agent CLI beyond the built-ins can be registered by dropping a `harness.json` next to the state file (`~/Library/Application Support/hrdx/` on macOS, `$XDG_CONFIG_HOME/hrdx/` on Linux, `%AppData%\hrdx\` on Windows). Registered harnesses appear everywhere the built-ins do: in the pickers, in agent cycling, as agent panes in the sidebar hierarchy, and in the settings window for enabling and disabling.
 
 ```json
 [

--- a/internal/ui/harness.go
+++ b/internal/ui/harness.go
@@ -9,9 +9,9 @@ import (
 )
 
 // Custom harnesses extend the built-in agent list with user-defined coding
-// agent CLIs. They are declared in harness.json next to the state file
-// and behave like built-ins everywhere: pickers, cycling, the sidebar
-// agents section, settings toggles, resume-on-restore, and busy tracking.
+// agent CLIs. They are declared in harness.json next to the state file and
+// behave like built-ins everywhere: pickers, cycling, sidebar pane identity,
+// settings toggles, resume-on-restore, and busy tracking.
 
 const harnessFile = "harness.json"
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1990,7 +1990,7 @@ func (m Model) sidebarRows() []sidebarRow {
 
 	rows = append(rows,
 		sidebarRow{},
-		sidebarRow{label: styleNewButton.Render("+ new workspace"), kind: "new", space: -1, tab: -1, pane: -1},
+		sidebarRow{label: " " + styleNewButton.Render("+ new workspace"), kind: "new", space: -1, tab: -1, pane: -1},
 	)
 	return rows
 }
@@ -2219,7 +2219,7 @@ func (m Model) renderSidebar() string {
 	// (●○↑↓), U+2699 is uncommon enough that some fonts (Windows
 	// Terminal's default among them) substitute a wider fallback glyph
 	// for it, which then overlaps a single following space.
-	rows = append(rows, stylePaneDim.Render("⚙  settings"), "")
+	rows = append(rows, " "+stylePaneDim.Render("⚙  settings"), "")
 
 	return lipgloss.NewStyle().
 		Width(sidebarWidth).

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1851,7 +1851,7 @@ func (m Model) paneBusy(currentPane *pane) bool {
 
 // sidebarPaneIcon distinguishes shells from agents while using shape,
 // color, and animation to expose the pane state. Agent panes animate only
-// while they are actively working; an idle agent process stays a diamond.
+// while they are actively working; an idle agent process stays a robot.
 func (m Model) sidebarPaneIcon(currentPane *pane) string {
 	return paneTypeStateIcon(
 		currentPane,
@@ -1861,6 +1861,13 @@ func (m Model) sidebarPaneIcon(currentPane *pane) string {
 	)
 }
 
+func paneIconCell(style lipgloss.Style, glyph string) string {
+	if lipgloss.Width(glyph) < 2 {
+		glyph += " "
+	}
+	return style.Render(glyph)
+}
+
 func paneTypeStateIcon(currentPane *pane, agent, busy bool, frame int) string {
 	runningGlyph, stoppedGlyph := "●", "○"
 	if agent {
@@ -1868,15 +1875,15 @@ func paneTypeStateIcon(currentPane *pane, agent, busy bool, frame int) string {
 	}
 	switch {
 	case currentPane.failure != "":
-		return styleDotOff.Render(stoppedGlyph)
+		return paneIconCell(styleDotOff, stoppedGlyph)
 	case agent && busy:
-		return styleDotBusy.Render(spinnerFrames[frame%len(spinnerFrames)])
+		return paneIconCell(styleDotBusy, spinnerFrames[frame%len(spinnerFrames)])
 	case currentPane.running:
-		return styleDotOn.Render(runningGlyph)
+		return paneIconCell(styleDotOn, runningGlyph)
 	case currentPane.term == nil:
-		return stylePaneDim.Render(stoppedGlyph)
+		return paneIconCell(stylePaneDim, stoppedGlyph)
 	default:
-		return styleDotOff.Render(stoppedGlyph)
+		return paneIconCell(styleDotOff, stoppedGlyph)
 	}
 }
 
@@ -1894,15 +1901,19 @@ func sidebarPaneState(currentPane *pane) string {
 }
 
 func (m Model) sidebarRows() []sidebarRow {
-	rows := []sidebarRow{}
+	rows := []sidebarRow{{}}
 	for spaceIndex, currentSpace := range m.spaces {
-		style := styleSpaceDim
+		if spaceIndex > 0 {
+			rows = append(rows, sidebarRow{
+				label: "  " + styleDivider.Render(strings.Repeat("─", sidebarWidth-4)),
+				kind:  "divider", space: spaceIndex, tab: -1, pane: -1,
+			})
+		}
 		rail := " "
 		if spaceIndex == m.selected {
-			style = styleSpaceSel
 			rail = styleSpaceSel.Render("▍")
 		}
-		label := rail + style.Render(truncate(currentSpace.name, sidebarWidth-3))
+		label := rail + styleSpaceDim.Render(truncate(currentSpace.name, sidebarWidth-3))
 		rows = append(rows, sidebarRow{
 			label: label,
 			kind:  "space", space: spaceIndex, tab: -1, pane: -1,
@@ -1920,8 +1931,12 @@ func (m Model) sidebarRows() []sidebarRow {
 				suffix += lipgloss.NewStyle().Foreground(colorAlt).Render(text)
 				suffixWidth += lipgloss.Width(text)
 			}
+			branchStyle := stylePaneDim
+			if spaceIndex == m.selected {
+				branchStyle = styleSpaceSel
+			}
 			rows = append(rows, sidebarRow{
-				label: rail + stylePaneDim.Render(truncate(branch.value, sidebarWidth-3-suffixWidth)) + suffix,
+				label: rail + branchStyle.Render(truncate(branch.value, sidebarWidth-3-suffixWidth)) + suffix,
 				kind:  "space", space: spaceIndex, tab: -1, pane: -1,
 			})
 		}
@@ -1929,7 +1944,7 @@ func (m Model) sidebarRows() []sidebarRow {
 		showTabs := len(currentSpace.tabs) > 1
 		for tabIndex, currentTab := range currentSpace.tabs {
 			paneIndent := rail + "  "
-			paneNameWidth := sidebarWidth - 6
+			paneNameWidth := sidebarWidth - 7
 			if showTabs {
 				tabStyle := stylePaneDim
 				tabMarker := "  "
@@ -1942,7 +1957,7 @@ func (m Model) sidebarRows() []sidebarRow {
 					kind:  "tab", space: spaceIndex, tab: tabIndex, pane: -1,
 				})
 				paneIndent = rail + "    "
-				paneNameWidth = sidebarWidth - 8
+				paneNameWidth = sidebarWidth - 9
 			}
 
 			for paneIndex, currentPane := range currentTab.panes {
@@ -1956,10 +1971,14 @@ func (m Model) sidebarRows() []sidebarRow {
 					stateWidth++
 				}
 				name := truncate(m.paneDisplayName(currentPane), paneNameWidth-stateWidth)
-				nameLabel := stylePaneDim.Render(name)
-				if selected {
-					nameLabel = stylePaneSel.Render(name)
+				nameStyle := stylePaneDim
+				if currentPane.running {
+					nameStyle = stylePaneRun
 				}
+				if selected {
+					nameStyle = stylePaneSel
+				}
+				nameLabel := nameStyle.Render(name)
 				rows = append(rows, sidebarRow{
 					label: paneIndent + m.sidebarPaneIcon(currentPane) + " " + nameLabel + state,
 					kind:  "pane", space: spaceIndex, tab: tabIndex, pane: paneIndex,

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1545,19 +1545,19 @@ func (m Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// A workspace drag in the sidebar reorders the list. Rows under the
-	// cursor resolve through sidebarHit, so dragging across pane rows or
-	// branch rows targets their workspace too.
+	// A workspace drag in the sidebar reorders the list. Descendant rows
+	// resolve to their owning workspace, so they remain useful drag targets.
 	if m.dragSpace != nil {
 		switch msg.Action {
 		case tea.MouseActionMotion:
 			if msg.X > sidebarWidth {
 				return m, nil
 			}
-			kind, index, _ := m.sidebarHit(msg.Y - 1)
-			if (kind == "space" || kind == "pane") && index >= 0 && index < len(m.spaces) &&
-				m.spaces[index] != m.dragSpace {
-				if m.moveSpaceTo(m.dragSpace, index) {
+			hit := m.sidebarHit(msg.Y - 1)
+			descendant := hit.kind == "space" || hit.kind == "tab" || hit.kind == "pane"
+			if descendant && hit.space >= 0 && hit.space < len(m.spaces) &&
+				m.spaces[hit.space] != m.dragSpace {
+				if m.moveSpaceTo(m.dragSpace, hit.space) {
 					m.dragMoved = true
 				}
 			}
@@ -1718,13 +1718,14 @@ func (m Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Right-click anywhere on a workspace's sidebar rows (name, branch,
-	// panes) opens the workspace context menu next to the cursor.
+	// Right-click anywhere in a workspace hierarchy opens the workspace
+	// context menu next to the cursor.
 	if msg.Button == tea.MouseButtonRight && msg.Action == tea.MouseActionPress {
-		kind, index, _ := m.sidebarHit(msg.Y - 1)
-		if (kind == "space" || kind == "pane") && index >= 0 && index < len(m.spaces) {
-			m.selected = index
-			m.openSpaceMenu(m.spaces[index], rect{x: msg.X, y: msg.Y - 1})
+		hit := m.sidebarHit(msg.Y - 1)
+		descendant := hit.kind == "space" || hit.kind == "tab" || hit.kind == "pane"
+		if descendant && hit.space >= 0 && hit.space < len(m.spaces) {
+			m.selected = hit.space
+			m.openSpaceMenu(m.spaces[hit.space], rect{x: msg.X, y: msg.Y - 1})
 		}
 		return m, nil
 	}
@@ -1733,21 +1734,33 @@ func (m Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	// The sidebar starts at body row 0 (screen row 1).
-	kind, index, sub := m.sidebarHit(msg.Y - 1)
-	switch kind {
+	hit := m.sidebarHit(msg.Y - 1)
+	switch hit.kind {
 	case "space":
-		if index >= 0 && index < len(m.spaces) {
-			m.selected = index
+		if hit.space >= 0 && hit.space < len(m.spaces) {
+			m.selected = hit.space
 			// Arm a reorder drag; a plain click releases without motion
 			// and leaves the order untouched.
-			m.dragSpace = m.spaces[index]
+			m.dragSpace = m.spaces[hit.space]
 			m.dragMoved = false
 		}
+	case "tab":
+		if hit.space >= 0 && hit.space < len(m.spaces) {
+			target := m.spaces[hit.space]
+			if hit.tab >= 0 && hit.tab < len(target.tabs) {
+				m.selected = hit.space
+				target.active = hit.tab
+				m.resizePanes(target)
+				m.persist()
+			}
+		}
 	case "pane":
-		if index >= 0 && index < len(m.spaces) {
-			m.selected = index
-			if target := m.paneByIndex(m.spaces[index], sub); target != nil {
-				m.focusPane(m.spaces[index], target)
+		if hit.space >= 0 && hit.space < len(m.spaces) {
+			target := m.spaces[hit.space]
+			if hit.tab >= 0 && hit.tab < len(target.tabs) &&
+				hit.pane >= 0 && hit.pane < len(target.tabs[hit.tab].panes) {
+				m.selected = hit.space
+				m.focusPane(target, target.tabs[hit.tab].panes[hit.pane])
 			}
 		}
 	case "new":
@@ -1777,20 +1790,6 @@ func (m *Model) moveSpaceTo(target *space, index int) bool {
 	m.spaces[index] = target
 	m.selected = index
 	return true
-}
-
-// paneByIndex resolves a flat pane index (across tabs) for sidebar rows.
-func (m *Model) paneByIndex(owner *space, flat int) *pane {
-	count := 0
-	for _, currentTab := range owner.tabs {
-		for _, currentPane := range currentTab.panes {
-			if count == flat {
-				return currentPane
-			}
-			count++
-		}
-	}
-	return nil
 }
 
 func (m *Model) applyDrag(localX, localY int) {
@@ -1825,12 +1824,13 @@ func (m *Model) focusPane(owner *space, target *pane) {
 }
 
 // sidebarRow is one clickable line of the sidebar. kind is "", "space",
-// "pane", or "new". The render and the mouse hit test share this layout so
-// they can never drift apart.
+// "tab", "pane", or "new". The render and mouse hit test share this layout
+// so they can never drift apart.
 type sidebarRow struct {
 	label string
 	kind  string
 	space int
+	tab   int
 	pane  int
 }
 
@@ -1849,51 +1849,63 @@ func (m Model) paneBusy(currentPane *pane) bool {
 	return currentPane.term.HasSpinner()
 }
 
-func (m Model) paneIcon(currentPane *pane) string {
-	return paneStateIcon(currentPane, m.paneBusy(currentPane), true, m.spinFrame)
+// sidebarPaneIcon distinguishes shells from agents while using shape,
+// color, and animation to expose the pane state. Agent panes animate only
+// while they are actively working; an idle agent process stays a diamond.
+func (m Model) sidebarPaneIcon(currentPane *pane) string {
+	return paneTypeStateIcon(
+		currentPane,
+		m.paneAgentKind(currentPane) != "",
+		m.paneBusy(currentPane),
+		m.spinFrame,
+	)
 }
 
-func (m Model) workspacePaneIcon(currentPane *pane) string {
-	return paneStateIcon(currentPane, m.paneBusy(currentPane), false, m.spinFrame)
+func paneTypeStateIcon(currentPane *pane, agent, busy bool, frame int) string {
+	runningGlyph, stoppedGlyph := "●", "○"
+	if agent {
+		runningGlyph, stoppedGlyph = "◆", "◇"
+	}
+	switch {
+	case currentPane.failure != "":
+		return styleDotOff.Render(stoppedGlyph)
+	case agent && busy:
+		return styleDotBusy.Render(spinnerFrames[frame%len(spinnerFrames)])
+	case currentPane.running:
+		return styleDotOn.Render(runningGlyph)
+	case currentPane.term == nil:
+		return stylePaneDim.Render(stoppedGlyph)
+	default:
+		return styleDotOff.Render(stoppedGlyph)
+	}
 }
 
-func paneStateIcon(currentPane *pane, busy, animate bool, frame int) string {
-	if currentPane.failure != "" {
-		return styleDotOff.Render("!")
+func sidebarPaneState(currentPane *pane) string {
+	switch {
+	case currentPane.failure != "":
+		return styleDotOff.Render("failed")
+	case !currentPane.running && currentPane.term != nil:
+		return styleDotOff.Render("exited")
+	case currentPane.term == nil:
+		return stylePaneDim.Render("starting")
+	default:
+		return ""
 	}
-	if busy {
-		if animate {
-			return styleDotBusy.Render(spinnerFrames[frame])
-		}
-		return styleDotBusy.Render("●")
-	}
-	if currentPane.running {
-		return styleDotOn.Render("●")
-	}
-	if currentPane.term == nil {
-		return stylePaneDim.Render("○")
-	}
-	return styleDotOff.Render("○")
 }
 
 func (m Model) sidebarRows() []sidebarRow {
-	// Leading blank row gives the same breathing room as the left margin.
-	rows := []sidebarRow{
-		{},
-		{label: " " + styleSection.Render("WORKSPACES")},
-	}
-
+	rows := []sidebarRow{}
 	for spaceIndex, currentSpace := range m.spaces {
 		style := styleSpaceDim
-		marker := "  "
+		rail := " "
 		if spaceIndex == m.selected {
 			style = styleSpaceSel
-			marker = " " + styleSpaceSel.Render("▍")
+			rail = styleSpaceSel.Render("▍")
 		}
-		label := marker + style.Render(truncate(currentSpace.name, sidebarWidth-4))
+		label := rail + style.Render(truncate(currentSpace.name, sidebarWidth-3))
 		rows = append(rows, sidebarRow{
 			label: label,
-			kind:  "space", space: spaceIndex, pane: -1,
+			kind:  "space", space: spaceIndex, tab: -1, pane: -1,
 		})
 		if branch := m.gitBranch(currentSpace.cwd); branch.value != "" {
 			suffixWidth := 0
@@ -1909,96 +1921,77 @@ func (m Model) sidebarRows() []sidebarRow {
 				suffixWidth += lipgloss.Width(text)
 			}
 			rows = append(rows, sidebarRow{
-				label: "  " + stylePaneDim.Render(truncate(branch.value, sidebarWidth-4-suffixWidth)) + suffix,
-				kind:  "space", space: spaceIndex, pane: -1,
+				label: rail + stylePaneDim.Render(truncate(branch.value, sidebarWidth-3-suffixWidth)) + suffix,
+				kind:  "space", space: spaceIndex, tab: -1, pane: -1,
 			})
 		}
-		flat := 0
-		for _, currentTab := range currentSpace.tabs {
-			for _, currentPane := range currentTab.panes {
+
+		showTabs := len(currentSpace.tabs) > 1
+		for tabIndex, currentTab := range currentSpace.tabs {
+			paneIndent := rail + "  "
+			paneNameWidth := sidebarWidth - 6
+			if showTabs {
+				tabStyle := stylePaneDim
+				tabMarker := "  "
+				if tabIndex == currentSpace.active {
+					tabStyle = styleSpaceSel
+					tabMarker = "▸ "
+				}
+				rows = append(rows, sidebarRow{
+					label: rail + " " + tabMarker + tabStyle.Render(truncate(tabDisplayName(currentTab, tabIndex), sidebarWidth-6)),
+					kind:  "tab", space: spaceIndex, tab: tabIndex, pane: -1,
+				})
+				paneIndent = rail + "    "
+				paneNameWidth = sidebarWidth - 8
+			}
+
+			for paneIndex, currentPane := range currentTab.panes {
 				selected := spaceIndex == m.selected &&
-					currentTab == currentSpace.tabs[currentSpace.active] &&
-					currentTab.panes[currentTab.selected] == currentPane
-				name := truncate(m.paneDisplayName(currentPane), sidebarWidth-10)
+					tabIndex == currentSpace.active &&
+					paneIndex == currentTab.selected
+				state := sidebarPaneState(currentPane)
+				stateWidth := lipgloss.Width(state)
+				if state != "" {
+					state = " " + state
+					stateWidth++
+				}
+				name := truncate(m.paneDisplayName(currentPane), paneNameWidth-stateWidth)
 				nameLabel := stylePaneDim.Render(name)
 				if selected {
 					nameLabel = stylePaneSel.Render(name)
 				}
 				rows = append(rows, sidebarRow{
-					label: "    " + m.workspacePaneIcon(currentPane) + " " + nameLabel,
-					kind:  "pane", space: spaceIndex, pane: flat,
+					label: paneIndent + m.sidebarPaneIcon(currentPane) + " " + nameLabel + state,
+					kind:  "pane", space: spaceIndex, tab: tabIndex, pane: paneIndex,
 				})
-				flat++
 			}
 		}
 	}
 
 	rows = append(rows,
 		sidebarRow{},
-		sidebarRow{label: " " + styleNewButton.Render("+ new workspace"), kind: "new", space: -1, pane: -1},
-		sidebarRow{},
-		sidebarRow{label: " " + styleSection.Render("AGENTS")},
+		sidebarRow{label: styleNewButton.Render("+ new workspace"), kind: "new", space: -1, tab: -1, pane: -1},
 	)
-
-	for spaceIndex, currentSpace := range m.spaces {
-		flat := -1
-		for _, currentTab := range currentSpace.tabs {
-			for _, currentPane := range currentTab.panes {
-				flat++
-				agentKind := m.paneAgentKind(currentPane)
-				if agentKind == "" {
-					continue
-				}
-				// Only abnormal states get a word; the spinner already
-				// tells working apart from idle. Agents inside shell
-				// panes vanish from the list when they exit, so those
-				// states only apply to dedicated agent panes.
-				stateLabel := ""
-				switch {
-				case currentPane.failure != "":
-					stateLabel = " " + styleDotOff.Render("failed")
-				case !currentPane.running && currentPane.term != nil:
-					stateLabel = " " + styleDotOff.Render("exited")
-				case currentPane.term == nil:
-					stateLabel = " " + stylePaneDim.Render("starting")
-				}
-				name := truncate(m.paneDisplayName(currentPane), sidebarWidth-6)
-				nameLabel := stylePaneDim.Render(name)
-				if spaceIndex == m.selected && m.currentPane() == currentPane {
-					nameLabel = stylePaneSel.Render(name)
-				}
-				rows = append(rows, sidebarRow{
-					label: "  " + m.paneIcon(currentPane) + " " + nameLabel + stateLabel,
-					kind:  "pane", space: spaceIndex, pane: flat,
-				})
-				rows = append(rows, sidebarRow{
-					label: "      " + stylePaneDim.Render(truncate(currentSpace.name, sidebarWidth-7)),
-					kind:  "pane", space: spaceIndex, pane: flat,
-				})
-			}
-		}
-	}
 	return rows
 }
 
 // sidebarHit maps a body row (header already subtracted) to a sidebar
 // entry, accounting for the sidebar scroll offset. The bottom row is the
 // pinned settings entry.
-func (m Model) sidebarHit(y int) (kind string, index, sub int) {
+func (m Model) sidebarHit(y int) sidebarRow {
 	height := max(3, m.height-2)
 	if y == height-2 {
-		return "settings", -1, -1
+		return sidebarRow{kind: "settings", space: -1, tab: -1, pane: -1}
 	}
 	if y == height-1 {
-		return "", -1, -1
+		return sidebarRow{}
 	}
 	rows := m.sidebarRows()
 	y += m.sidebarOffset(len(rows))
 	if y < 0 || y >= len(rows) {
-		return "", -1, -1
+		return sidebarRow{}
 	}
-	hit := rows[y]
-	return hit.kind, hit.space, hit.pane
+	return rows[y]
 }
 
 // sidebarOffset clamps the scroll offset to the overflow of the row list.
@@ -2106,12 +2099,15 @@ func (m Model) tabCells(target *space) []tabCell {
 	return cells
 }
 
-func (m Model) tabLabel(target *tab, index int) string {
-	name := target.name
-	if name == "" {
-		name = fmt.Sprintf("%d", index+1)
+func tabDisplayName(target *tab, index int) string {
+	if target.name != "" {
+		return target.name
 	}
-	return " " + truncate(name, 16) + " "
+	return fmt.Sprintf("%d", index+1)
+}
+
+func (m Model) tabLabel(target *tab, index int) string {
+	return " " + truncate(tabDisplayName(target, index), 16) + " "
 }
 
 // tabHit maps a local x on the tab bar to a tab index or the + button.
@@ -2184,8 +2180,8 @@ func (m Model) renderSidebar() string {
 	}
 
 	height := max(3, m.height-2)
-	// The two bottom rows are the pinned settings entry and a trailing
-	// blank line matching the blank line above WORKSPACES.
+	// The two bottom rows are the pinned settings entry and trailing space
+	// that keeps it clear of the footer.
 	list := height - 2
 	for len(rows) < list {
 		rows = append(rows, "")
@@ -2194,16 +2190,16 @@ func (m Model) renderSidebar() string {
 
 	// Overflow markers so hidden rows are discoverable.
 	if offset > 0 {
-		rows[0] = " " + stylePaneDim.Render("↑ more")
+		rows[0] = stylePaneDim.Render("↑ more")
 	}
 	if offset < len(source)-list {
-		rows[list-1] = " " + stylePaneDim.Render("↓ more")
+		rows[list-1] = stylePaneDim.Render("↓ more")
 	}
 	// Extra trailing space after the gear: unlike the other sidebar icons
 	// (●○↑↓), U+2699 is uncommon enough that some fonts (Windows
 	// Terminal's default among them) substitute a wider fallback glyph
 	// for it, which then overlaps a single following space.
-	rows = append(rows, " "+stylePaneDim.Render("⚙  settings"), "")
+	rows = append(rows, stylePaneDim.Render("⚙  settings"), "")
 
 	return lipgloss.NewStyle().
 		Width(sidebarWidth).

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1849,9 +1849,9 @@ func (m Model) paneBusy(currentPane *pane) bool {
 	return currentPane.term.HasSpinner()
 }
 
-// sidebarPaneIcon distinguishes shells from agents while using shape,
-// color, and animation to expose the pane state. Agent panes animate only
-// while they are actively working; an idle agent process stays a robot.
+// sidebarPaneIcon uses a shared dot shape for shells and agents while
+// color and animation expose pane state. Agents animate only while active;
+// an idle agent process stays a dot.
 func (m Model) sidebarPaneIcon(currentPane *pane) string {
 	return paneTypeStateIcon(
 		currentPane,
@@ -1870,9 +1870,6 @@ func paneIconCell(style lipgloss.Style, glyph string) string {
 
 func paneTypeStateIcon(currentPane *pane, agent, busy bool, frame int) string {
 	runningGlyph, stoppedGlyph := "●", "○"
-	if agent {
-		runningGlyph, stoppedGlyph = "◆", "◇"
-	}
 	switch {
 	case currentPane.failure != "":
 		return paneIconCell(styleDotOff, stoppedGlyph)
@@ -1901,7 +1898,11 @@ func sidebarPaneState(currentPane *pane) string {
 }
 
 func (m Model) sidebarRows() []sidebarRow {
-	rows := []sidebarRow{{}}
+	rows := []sidebarRow{
+		{},
+		{label: " " + styleSection.Render("WORKSPACES")},
+		{},
+	}
 	for spaceIndex, currentSpace := range m.spaces {
 		if spaceIndex > 0 {
 			rows = append(rows, sidebarRow{

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -93,21 +93,21 @@ func TestTabHit(t *testing.T) {
 func TestSidebarHitMapsHierarchyRows(t *testing.T) {
 	model := newTestModel("/tmp/api", "/tmp/web")
 
-	// Singleton tabs are elided: 0 space api, 1 pane api/zot,
-	// 2 space web, 3 pane web/zot, 4 blank, 5 new.
-	hit := model.sidebarHit(0)
+	// Singleton tabs are elided: 0 top spacer, 1 space api, 2 pane api/zot,
+	// 3 divider, 4 space web, 5 pane web/zot, 6 blank, 7 new.
+	hit := model.sidebarHit(1)
 	if hit.kind != "space" || hit.space != 0 {
-		t.Fatalf("row 0 = %+v, want space 0", hit)
+		t.Fatalf("row 1 = %+v, want space 0", hit)
 	}
-	hit = model.sidebarHit(1)
+	hit = model.sidebarHit(2)
 	if hit.kind != "pane" || hit.space != 0 || hit.tab != 0 || hit.pane != 0 {
-		t.Fatalf("row 1 = %+v, want space 0 tab 0 pane 0", hit)
+		t.Fatalf("row 2 = %+v, want space 0 tab 0 pane 0", hit)
 	}
-	if hit = model.sidebarHit(2); hit.kind != "space" || hit.space != 1 {
-		t.Fatalf("row 2 = %+v, want space 1 without a separator", hit)
+	if hit = model.sidebarHit(3); hit.kind != "divider" || !strings.HasPrefix(hit.label, "  ") || strings.Contains(hit.label, "└") {
+		t.Fatalf("row 3 = %+v, want an indented divider detached from the selection rail", hit)
 	}
-	if hit = model.sidebarHit(5); hit.kind != "new" {
-		t.Fatalf("row 5 = %+v, want new workspace", hit)
+	if hit = model.sidebarHit(7); hit.kind != "new" {
+		t.Fatalf("row 7 = %+v, want new workspace", hit)
 	}
 
 	panes, tabs := 0, 0
@@ -132,7 +132,7 @@ func TestBranchStaysWithWorkspaceName(t *testing.T) {
 	model.selected = 1
 	model.branches["/tmp/api"] = branchInfo{value: "main", checked: time.Now()}
 	rows := model.sidebarRows()
-	workspaceRow, branchRow := rows[0], rows[1]
+	workspaceRow, branchRow := rows[1], rows[2]
 	if workspaceRow.kind != "space" || branchRow.kind != "space" || !strings.Contains(branchRow.label, "main") {
 		t.Fatalf("branch must immediately follow its workspace: %+v, %+v", workspaceRow, branchRow)
 	}
@@ -149,7 +149,7 @@ func TestSelectedWorkspaceRailSpansHierarchy(t *testing.T) {
 
 	rail := styleSpaceSel.Render("▍")
 	rows := model.sidebarRows()
-	for index := 0; index <= 5; index++ {
+	for index := 1; index <= 6; index++ {
 		if !strings.HasPrefix(rows[index].label, rail) {
 			t.Fatalf("row %d does not continue selected workspace rail: %q", index, rows[index].label)
 		}
@@ -159,7 +159,7 @@ func TestSelectedWorkspaceRailSpansHierarchy(t *testing.T) {
 func TestSidebarPaneRowsDistinguishShellsAndAgents(t *testing.T) {
 	model := newTestModel("/tmp/api")
 	rows := model.sidebarRows()
-	workspacePane := rows[1]
+	workspacePane := rows[2]
 	if !strings.Contains(workspacePane.label, "◇") || !strings.Contains(workspacePane.label, "starting") {
 		t.Fatalf("starting agent row lacks type or state: %q", workspacePane.label)
 	}
@@ -170,15 +170,18 @@ func TestSidebarPaneRowsDistinguishShellsAndAgents(t *testing.T) {
 	}
 
 	shell := &pane{kind: "shell", running: true}
-	if got, want := paneTypeStateIcon(shell, false, false, 0), styleDotOn.Render("●"); got != want {
+	if got, want := paneTypeStateIcon(shell, false, false, 0), paneIconCell(styleDotOn, "●"); got != want {
 		t.Fatalf("running shell icon = %q, want %q", got, want)
 	}
 	agent := &pane{kind: "zot", running: true}
-	if got, want := paneTypeStateIcon(agent, true, false, 0), styleDotOn.Render("◆"); got != want {
+	if got, want := paneTypeStateIcon(agent, true, false, 0), paneIconCell(styleDotOn, "◆"); got != want {
 		t.Fatalf("idle agent icon = %q, want %q", got, want)
 	}
-	if got, want := paneTypeStateIcon(agent, true, true, 0), styleDotBusy.Render(spinnerFrames[0]); got != want {
+	if got, want := paneTypeStateIcon(agent, true, true, 0), paneIconCell(styleDotBusy, spinnerFrames[0]); got != want {
 		t.Fatalf("busy agent icon = %q, want animated spinner %q", got, want)
+	}
+	if width := lipgloss.Width(paneTypeStateIcon(agent, true, false, 0)); width != 2 {
+		t.Fatalf("agent icon width = %d, want fixed two-cell column", width)
 	}
 }
 
@@ -241,8 +244,8 @@ func TestSidebarScrollClamps(t *testing.T) {
 
 func TestMouseSelectsSpace(t *testing.T) {
 	model := newTestModel("/tmp/api", "/tmp/web")
-	// Singleton tabs are hidden, so sidebar row 2 (space web) is screen Y=3.
-	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 3, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	// Sidebar row 4 (space web) is screen Y=5.
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
 	got := updated.(Model)
 	if got.selected != 1 {
 		t.Fatalf("selected = %d, want 1", got.selected)
@@ -255,16 +258,16 @@ func TestMouseSelectsSidebarTabAndPane(t *testing.T) {
 	model.addTab(currentSpace, "shell")
 	currentSpace.active = 0
 
-	// Sidebar rows: 0 workspace, 1 tab 1, 2 pane, 3 tab 2, 4 pane.
+	// Sidebar rows: 1 workspace, 2 tab 1, 3 pane, 4 tab 2, 5 pane.
 	// Screen Y is sidebar row + 1.
-	updated, _ := model.updateMouse(tea.MouseMsg{X: 5, Y: 4, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 5, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
 	got := updated.(Model)
 	if got.spaces[0].active != 1 {
 		t.Fatalf("active tab = %d, want 1 after clicking tab row", got.spaces[0].active)
 	}
 
 	got.spaces[0].active = 0
-	updated, _ = got.updateMouse(tea.MouseMsg{X: 7, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	updated, _ = got.updateMouse(tea.MouseMsg{X: 7, Y: 6, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
 	got = updated.(Model)
 	if got.spaces[0].active != 1 || got.spaces[0].tabs[1].selected != 0 {
 		t.Fatalf("active tab/pane = %d/%d, want 1/0 after clicking pane row",
@@ -306,16 +309,16 @@ func TestSidebarDragReordersSpaces(t *testing.T) {
 	model := newTestModel("/tmp/api", "/tmp/web")
 	api, web := model.spaces[0], model.spaces[1]
 
-	// Rows: 0 space api, 1 pane, 2 space web, 3 pane.
+	// Rows: 0 spacer, 1 space api, 2 pane, 3 divider, 4 space web, 5 pane.
 	// Screen Y is row + 1.
-	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 1, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 2, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
 	got := updated.(Model)
 	if got.dragSpace != api {
 		t.Fatal("press on a workspace row should arm the drag")
 	}
 
 	// Drag down onto web's pane row: api moves below web.
-	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 4, Button: tea.MouseButtonLeft, Action: tea.MouseActionMotion})
+	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 6, Button: tea.MouseButtonLeft, Action: tea.MouseActionMotion})
 	got = updated.(Model)
 	if got.spaces[0] != web || got.spaces[1] != api {
 		t.Fatalf("order after drag = %s/%s, want web/api", got.spaces[0].name, got.spaces[1].name)
@@ -324,7 +327,7 @@ func TestSidebarDragReordersSpaces(t *testing.T) {
 		t.Fatalf("selected = %d, want 1 (follows the dragged space)", got.selected)
 	}
 
-	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 4, Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease})
+	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 6, Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease})
 	got = updated.(Model)
 	if got.dragSpace != nil || got.dragMoved {
 		t.Fatal("release should clear the drag state")
@@ -335,9 +338,9 @@ func TestSidebarClickWithoutMotionKeepsOrder(t *testing.T) {
 	model := newTestModel("/tmp/api", "/tmp/web")
 	api := model.spaces[0]
 
-	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 1, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 2, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
 	got := updated.(Model)
-	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 1, Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease})
+	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 2, Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease})
 	got = updated.(Model)
 	if got.spaces[0] != api {
 		t.Fatal("a plain click must not reorder workspaces")

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -90,54 +90,94 @@ func TestTabHit(t *testing.T) {
 	}
 }
 
-func TestSidebarHitMapsRows(t *testing.T) {
+func TestSidebarHitMapsHierarchyRows(t *testing.T) {
 	model := newTestModel("/tmp/api", "/tmp/web")
 
-	// Row layout without git branches (temp dirs are not repos):
-	// 0 blank, 1 WORKSPACES, 2 space api, 3 pane api/zot, 4 space web,
-	// 5 pane web/zot, 6 blank, 7 new workspace, 8 blank, 9 AGENTS, 10+.
-	kind, index, _ := model.sidebarHit(2)
-	if kind != "space" || index != 0 {
-		t.Fatalf("row 2 = %q/%d, want space/0", kind, index)
+	// Singleton tabs are elided: 0 space api, 1 pane api/zot,
+	// 2 space web, 3 pane web/zot, 4 blank, 5 new.
+	hit := model.sidebarHit(0)
+	if hit.kind != "space" || hit.space != 0 {
+		t.Fatalf("row 0 = %+v, want space 0", hit)
 	}
-	kind, index, sub := model.sidebarHit(3)
-	if kind != "pane" || index != 0 || sub != 0 {
-		t.Fatalf("row 3 = %q/%d/%d, want pane/0/0", kind, index, sub)
+	hit = model.sidebarHit(1)
+	if hit.kind != "pane" || hit.space != 0 || hit.tab != 0 || hit.pane != 0 {
+		t.Fatalf("row 1 = %+v, want space 0 tab 0 pane 0", hit)
 	}
-	kind, _, _ = model.sidebarHit(7)
-	if kind != "new" {
-		t.Fatalf("row 7 = %q, want new", kind)
+	if hit = model.sidebarHit(2); hit.kind != "space" || hit.space != 1 {
+		t.Fatalf("row 2 = %+v, want space 1 without a separator", hit)
+	}
+	if hit = model.sidebarHit(5); hit.kind != "new" {
+		t.Fatalf("row 5 = %+v, want new workspace", hit)
+	}
+
+	panes, tabs := 0, 0
+	for _, row := range model.sidebarRows() {
+		if strings.Contains(row.label, "WORKSPACES") || strings.Contains(row.label, "AGENTS") {
+			t.Fatalf("unified sidebar contains a section label: %q", row.label)
+		}
+		switch row.kind {
+		case "pane":
+			panes++
+		case "tab":
+			tabs++
+		}
+	}
+	if panes != 2 || tabs != 0 {
+		t.Fatalf("pane/tab rows = %d/%d, want 2/0 for singleton tabs", panes, tabs)
 	}
 }
 
-func TestBranchAlignsWithWorkspaceName(t *testing.T) {
-	model := newTestModel("/tmp/api")
+func TestBranchStaysWithWorkspaceName(t *testing.T) {
+	model := newTestModel("/tmp/api", "/tmp/web")
+	model.selected = 1
 	model.branches["/tmp/api"] = branchInfo{value: "main", checked: time.Now()}
 	rows := model.sidebarRows()
-	branchRow := rows[3]
-	if leading := len(branchRow.label) - len(strings.TrimLeft(branchRow.label, " ")); leading != 2 {
-		t.Fatalf("branch indentation = %d, want 2 to align with workspace name", leading)
+	workspaceRow, branchRow := rows[0], rows[1]
+	if workspaceRow.kind != "space" || branchRow.kind != "space" || !strings.Contains(branchRow.label, "main") {
+		t.Fatalf("branch must immediately follow its workspace: %+v, %+v", workspaceRow, branchRow)
+	}
+	if leading := len(branchRow.label) - len(strings.TrimLeft(branchRow.label, " ")); leading != 1 {
+		t.Fatalf("branch indentation = %d, want 1 to align with workspace name", leading)
 	}
 }
 
-func TestWorkspacePaneRowsUseStaticStateIcons(t *testing.T) {
+func TestSelectedWorkspaceRailSpansHierarchy(t *testing.T) {
+	model := newTestModel("/tmp/api")
+	model.selected = 0
+	model.branches["/tmp/api"] = branchInfo{value: "main", checked: time.Now()}
+	model.addTab(model.spaces[0], "shell")
+
+	rail := styleSpaceSel.Render("▍")
+	rows := model.sidebarRows()
+	for index := 0; index <= 5; index++ {
+		if !strings.HasPrefix(rows[index].label, rail) {
+			t.Fatalf("row %d does not continue selected workspace rail: %q", index, rows[index].label)
+		}
+	}
+}
+
+func TestSidebarPaneRowsDistinguishShellsAndAgents(t *testing.T) {
 	model := newTestModel("/tmp/api")
 	rows := model.sidebarRows()
-	workspacePane := rows[3]
-	if !strings.Contains(workspacePane.label, "○") {
-		t.Fatalf("workspace pane row has no state bullet: %q", workspacePane.label)
+	workspacePane := rows[1]
+	if !strings.Contains(workspacePane.label, "◇") || !strings.Contains(workspacePane.label, "starting") {
+		t.Fatalf("starting agent row lacks type or state: %q", workspacePane.label)
 	}
 	for _, frame := range spinnerFrames {
 		if strings.Contains(workspacePane.label, frame) {
-			t.Fatalf("workspace pane row contains an animated spinner: %q", workspacePane.label)
+			t.Fatalf("idle agent row contains an animated spinner: %q", workspacePane.label)
 		}
 	}
 
-	target := &pane{running: true}
-	if got, want := paneStateIcon(target, true, false, 0), styleDotBusy.Render("●"); got != want {
-		t.Fatalf("busy workspace icon = %q, want static busy bullet %q", got, want)
+	shell := &pane{kind: "shell", running: true}
+	if got, want := paneTypeStateIcon(shell, false, false, 0), styleDotOn.Render("●"); got != want {
+		t.Fatalf("running shell icon = %q, want %q", got, want)
 	}
-	if got, want := paneStateIcon(target, true, true, 0), styleDotBusy.Render(spinnerFrames[0]); got != want {
+	agent := &pane{kind: "zot", running: true}
+	if got, want := paneTypeStateIcon(agent, true, false, 0), styleDotOn.Render("◆"); got != want {
+		t.Fatalf("idle agent icon = %q, want %q", got, want)
+	}
+	if got, want := paneTypeStateIcon(agent, true, true, 0), styleDotBusy.Render(spinnerFrames[0]); got != want {
 		t.Fatalf("busy agent icon = %q, want animated spinner %q", got, want)
 	}
 }
@@ -201,11 +241,34 @@ func TestSidebarScrollClamps(t *testing.T) {
 
 func TestMouseSelectsSpace(t *testing.T) {
 	model := newTestModel("/tmp/api", "/tmp/web")
-	// Sidebar row 4 (space web) is at screen Y=5.
-	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	// Singleton tabs are hidden, so sidebar row 2 (space web) is screen Y=3.
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 3, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
 	got := updated.(Model)
 	if got.selected != 1 {
 		t.Fatalf("selected = %d, want 1", got.selected)
+	}
+}
+
+func TestMouseSelectsSidebarTabAndPane(t *testing.T) {
+	model := newTestModel("/tmp/api")
+	currentSpace := model.spaces[0]
+	model.addTab(currentSpace, "shell")
+	currentSpace.active = 0
+
+	// Sidebar rows: 0 workspace, 1 tab 1, 2 pane, 3 tab 2, 4 pane.
+	// Screen Y is sidebar row + 1.
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 5, Y: 4, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	got := updated.(Model)
+	if got.spaces[0].active != 1 {
+		t.Fatalf("active tab = %d, want 1 after clicking tab row", got.spaces[0].active)
+	}
+
+	got.spaces[0].active = 0
+	updated, _ = got.updateMouse(tea.MouseMsg{X: 7, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	got = updated.(Model)
+	if got.spaces[0].active != 1 || got.spaces[0].tabs[1].selected != 0 {
+		t.Fatalf("active tab/pane = %d/%d, want 1/0 after clicking pane row",
+			got.spaces[0].active, got.spaces[0].tabs[1].selected)
 	}
 }
 
@@ -243,16 +306,16 @@ func TestSidebarDragReordersSpaces(t *testing.T) {
 	model := newTestModel("/tmp/api", "/tmp/web")
 	api, web := model.spaces[0], model.spaces[1]
 
-	// Rows: 0 blank, 1 WORKSPACES, 2 space api, 3 pane, 4 space web,
-	// 5 pane. Screen Y is row + 1. Press on api's name arms the drag.
-	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 3, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	// Rows: 0 space api, 1 pane, 2 space web, 3 pane.
+	// Screen Y is row + 1.
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 1, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
 	got := updated.(Model)
 	if got.dragSpace != api {
 		t.Fatal("press on a workspace row should arm the drag")
 	}
 
-	// Drag down onto web's rows: api moves below web.
-	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionMotion})
+	// Drag down onto web's pane row: api moves below web.
+	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 4, Button: tea.MouseButtonLeft, Action: tea.MouseActionMotion})
 	got = updated.(Model)
 	if got.spaces[0] != web || got.spaces[1] != api {
 		t.Fatalf("order after drag = %s/%s, want web/api", got.spaces[0].name, got.spaces[1].name)
@@ -261,7 +324,7 @@ func TestSidebarDragReordersSpaces(t *testing.T) {
 		t.Fatalf("selected = %d, want 1 (follows the dragged space)", got.selected)
 	}
 
-	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease})
+	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 4, Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease})
 	got = updated.(Model)
 	if got.dragSpace != nil || got.dragMoved {
 		t.Fatal("release should clear the drag state")
@@ -272,9 +335,9 @@ func TestSidebarClickWithoutMotionKeepsOrder(t *testing.T) {
 	model := newTestModel("/tmp/api", "/tmp/web")
 	api := model.spaces[0]
 
-	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 3, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 1, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
 	got := updated.(Model)
-	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 3, Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease})
+	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 1, Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease})
 	got = updated.(Model)
 	if got.spaces[0] != api {
 		t.Fatal("a plain click must not reorder workspaces")

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -93,27 +93,35 @@ func TestTabHit(t *testing.T) {
 func TestSidebarHitMapsHierarchyRows(t *testing.T) {
 	model := newTestModel("/tmp/api", "/tmp/web")
 
-	// Singleton tabs are elided: 0 top spacer, 1 space api, 2 pane api/zot,
-	// 3 divider, 4 space web, 5 pane web/zot, 6 blank, 7 new.
-	hit := model.sidebarHit(1)
+	// Singleton tabs are elided: 0 top spacer, 1 WORKSPACES, 2 section gap,
+	// 3 space api, 4 pane api/zot, 5 divider, 6 space web, 7 pane web/zot,
+	// 8 blank, 9 new.
+	if gap := model.sidebarHit(2); gap.kind != "" || gap.label != "" {
+		t.Fatalf("row 2 = %+v, want blank section gap", gap)
+	}
+	hit := model.sidebarHit(3)
 	if hit.kind != "space" || hit.space != 0 {
-		t.Fatalf("row 1 = %+v, want space 0", hit)
+		t.Fatalf("row 3 = %+v, want space 0", hit)
 	}
-	hit = model.sidebarHit(2)
+	hit = model.sidebarHit(4)
 	if hit.kind != "pane" || hit.space != 0 || hit.tab != 0 || hit.pane != 0 {
-		t.Fatalf("row 2 = %+v, want space 0 tab 0 pane 0", hit)
+		t.Fatalf("row 4 = %+v, want space 0 tab 0 pane 0", hit)
 	}
-	if hit = model.sidebarHit(3); hit.kind != "divider" || !strings.HasPrefix(hit.label, "  ") || strings.Contains(hit.label, "└") {
-		t.Fatalf("row 3 = %+v, want an indented divider detached from the selection rail", hit)
+	if hit = model.sidebarHit(5); hit.kind != "divider" || !strings.HasPrefix(hit.label, "  ") || strings.Contains(hit.label, "└") {
+		t.Fatalf("row 5 = %+v, want an indented divider detached from the selection rail", hit)
 	}
-	if hit = model.sidebarHit(7); hit.kind != "new" {
-		t.Fatalf("row 7 = %+v, want new workspace", hit)
+	if hit = model.sidebarHit(9); hit.kind != "new" {
+		t.Fatalf("row 9 = %+v, want new workspace", hit)
 	}
 
 	panes, tabs := 0, 0
+	workspacesLabel := false
 	for _, row := range model.sidebarRows() {
-		if strings.Contains(row.label, "WORKSPACES") || strings.Contains(row.label, "AGENTS") {
-			t.Fatalf("unified sidebar contains a section label: %q", row.label)
+		if strings.Contains(row.label, "AGENTS") {
+			t.Fatalf("unified sidebar contains an AGENTS section label: %q", row.label)
+		}
+		if strings.Contains(row.label, "WORKSPACES") {
+			workspacesLabel = true
 		}
 		switch row.kind {
 		case "pane":
@@ -121,6 +129,9 @@ func TestSidebarHitMapsHierarchyRows(t *testing.T) {
 		case "tab":
 			tabs++
 		}
+	}
+	if !workspacesLabel {
+		t.Fatal("unified sidebar lacks the WORKSPACES section label")
 	}
 	if panes != 2 || tabs != 0 {
 		t.Fatalf("pane/tab rows = %d/%d, want 2/0 for singleton tabs", panes, tabs)
@@ -132,7 +143,7 @@ func TestBranchStaysWithWorkspaceName(t *testing.T) {
 	model.selected = 1
 	model.branches["/tmp/api"] = branchInfo{value: "main", checked: time.Now()}
 	rows := model.sidebarRows()
-	workspaceRow, branchRow := rows[1], rows[2]
+	workspaceRow, branchRow := rows[3], rows[4]
 	if workspaceRow.kind != "space" || branchRow.kind != "space" || !strings.Contains(branchRow.label, "main") {
 		t.Fatalf("branch must immediately follow its workspace: %+v, %+v", workspaceRow, branchRow)
 	}
@@ -149,19 +160,19 @@ func TestSelectedWorkspaceRailSpansHierarchy(t *testing.T) {
 
 	rail := styleSpaceSel.Render("▍")
 	rows := model.sidebarRows()
-	for index := 1; index <= 6; index++ {
+	for index := 3; index <= 8; index++ {
 		if !strings.HasPrefix(rows[index].label, rail) {
 			t.Fatalf("row %d does not continue selected workspace rail: %q", index, rows[index].label)
 		}
 	}
 }
 
-func TestSidebarPaneRowsDistinguishShellsAndAgents(t *testing.T) {
+func TestSidebarPaneRowsUseSharedShellAndAgentSymbols(t *testing.T) {
 	model := newTestModel("/tmp/api")
 	rows := model.sidebarRows()
-	workspacePane := rows[2]
-	if !strings.Contains(workspacePane.label, "◇") || !strings.Contains(workspacePane.label, "starting") {
-		t.Fatalf("starting agent row lacks type or state: %q", workspacePane.label)
+	workspacePane := rows[4]
+	if !strings.Contains(workspacePane.label, "○") || !strings.Contains(workspacePane.label, "starting") {
+		t.Fatalf("starting agent row lacks shared pane symbol or state: %q", workspacePane.label)
 	}
 	for _, frame := range spinnerFrames {
 		if strings.Contains(workspacePane.label, frame) {
@@ -174,8 +185,8 @@ func TestSidebarPaneRowsDistinguishShellsAndAgents(t *testing.T) {
 		t.Fatalf("running shell icon = %q, want %q", got, want)
 	}
 	agent := &pane{kind: "zot", running: true}
-	if got, want := paneTypeStateIcon(agent, true, false, 0), paneIconCell(styleDotOn, "◆"); got != want {
-		t.Fatalf("idle agent icon = %q, want %q", got, want)
+	if got, want := paneTypeStateIcon(agent, true, false, 0), paneIconCell(styleDotOn, "●"); got != want {
+		t.Fatalf("idle agent icon = %q, want shared shell icon %q", got, want)
 	}
 	if got, want := paneTypeStateIcon(agent, true, true, 0), paneIconCell(styleDotBusy, spinnerFrames[0]); got != want {
 		t.Fatalf("busy agent icon = %q, want animated spinner %q", got, want)
@@ -244,8 +255,8 @@ func TestSidebarScrollClamps(t *testing.T) {
 
 func TestMouseSelectsSpace(t *testing.T) {
 	model := newTestModel("/tmp/api", "/tmp/web")
-	// Sidebar row 4 (space web) is screen Y=5.
-	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	// Sidebar row 6 (space web) is screen Y=7.
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 7, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
 	got := updated.(Model)
 	if got.selected != 1 {
 		t.Fatalf("selected = %d, want 1", got.selected)
@@ -258,16 +269,16 @@ func TestMouseSelectsSidebarTabAndPane(t *testing.T) {
 	model.addTab(currentSpace, "shell")
 	currentSpace.active = 0
 
-	// Sidebar rows: 1 workspace, 2 tab 1, 3 pane, 4 tab 2, 5 pane.
+	// Sidebar rows: 3 workspace, 4 tab 1, 5 pane, 6 tab 2, 7 pane.
 	// Screen Y is sidebar row + 1.
-	updated, _ := model.updateMouse(tea.MouseMsg{X: 5, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 5, Y: 7, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
 	got := updated.(Model)
 	if got.spaces[0].active != 1 {
 		t.Fatalf("active tab = %d, want 1 after clicking tab row", got.spaces[0].active)
 	}
 
 	got.spaces[0].active = 0
-	updated, _ = got.updateMouse(tea.MouseMsg{X: 7, Y: 6, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	updated, _ = got.updateMouse(tea.MouseMsg{X: 7, Y: 8, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
 	got = updated.(Model)
 	if got.spaces[0].active != 1 || got.spaces[0].tabs[1].selected != 0 {
 		t.Fatalf("active tab/pane = %d/%d, want 1/0 after clicking pane row",
@@ -309,16 +320,16 @@ func TestSidebarDragReordersSpaces(t *testing.T) {
 	model := newTestModel("/tmp/api", "/tmp/web")
 	api, web := model.spaces[0], model.spaces[1]
 
-	// Rows: 0 spacer, 1 space api, 2 pane, 3 divider, 4 space web, 5 pane.
-	// Screen Y is row + 1.
-	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 2, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	// Rows: 0 spacer, 1 WORKSPACES, 2 section gap, 3 space api, 4 pane,
+	// 5 divider, 6 space web, 7 pane. Screen Y is row + 1.
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 4, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
 	got := updated.(Model)
 	if got.dragSpace != api {
 		t.Fatal("press on a workspace row should arm the drag")
 	}
 
 	// Drag down onto web's pane row: api moves below web.
-	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 6, Button: tea.MouseButtonLeft, Action: tea.MouseActionMotion})
+	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 8, Button: tea.MouseButtonLeft, Action: tea.MouseActionMotion})
 	got = updated.(Model)
 	if got.spaces[0] != web || got.spaces[1] != api {
 		t.Fatalf("order after drag = %s/%s, want web/api", got.spaces[0].name, got.spaces[1].name)
@@ -327,7 +338,7 @@ func TestSidebarDragReordersSpaces(t *testing.T) {
 		t.Fatalf("selected = %d, want 1 (follows the dragged space)", got.selected)
 	}
 
-	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 6, Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease})
+	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 8, Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease})
 	got = updated.(Model)
 	if got.dragSpace != nil || got.dragMoved {
 		t.Fatal("release should clear the drag state")

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -39,10 +39,12 @@ var (
 	styleSpaceSel  lipgloss.Style
 	styleSpaceDim  lipgloss.Style
 	stylePaneSel   lipgloss.Style
+	stylePaneRun   lipgloss.Style
 	stylePaneDim   lipgloss.Style
 	styleDotOn     lipgloss.Style
 	styleDotBusy   lipgloss.Style
 	styleDotOff    lipgloss.Style
+	styleDivider   lipgloss.Style
 	styleNewButton lipgloss.Style
 	styleMuted     lipgloss.Style
 	styleError     lipgloss.Style
@@ -64,12 +66,14 @@ func rebuildStyles() {
 	styleBadgeInput = lipgloss.NewStyle().Background(colorGood).Foreground(colorInk).Bold(true)
 
 	styleSpaceSel = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
-	styleSpaceDim = lipgloss.NewStyle().Foreground(colorBarFg)
+	styleSpaceDim = lipgloss.NewStyle().Foreground(colorBarFg).Bold(true)
 	stylePaneSel = lipgloss.NewStyle().Foreground(colorAccent)
+	stylePaneRun = lipgloss.NewStyle().Foreground(colorBarFg)
 	stylePaneDim = lipgloss.NewStyle().Foreground(colorMuted)
 	styleDotOn = lipgloss.NewStyle().Foreground(colorGood)
 	styleDotBusy = lipgloss.NewStyle().Foreground(colorBusy)
 	styleDotOff = lipgloss.NewStyle().Foreground(colorBad)
+	styleDivider = lipgloss.NewStyle().Foreground(colorFaint)
 	styleNewButton = lipgloss.NewStyle().Foreground(colorAccent)
 	styleMuted = lipgloss.NewStyle().Foreground(colorMuted)
 	styleError = lipgloss.NewStyle().Foreground(colorBad)

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -36,7 +36,6 @@ var (
 	styleBadgeInput  lipgloss.Style
 
 	// Sidebar.
-	styleSection   lipgloss.Style
 	styleSpaceSel  lipgloss.Style
 	styleSpaceDim  lipgloss.Style
 	stylePaneSel   lipgloss.Style
@@ -64,7 +63,6 @@ func rebuildStyles() {
 	styleBadgePrefix = lipgloss.NewStyle().Background(colorAlt).Foreground(colorInk).Bold(true)
 	styleBadgeInput = lipgloss.NewStyle().Background(colorGood).Foreground(colorInk).Bold(true)
 
-	styleSection = lipgloss.NewStyle().Foreground(colorMuted).Bold(true)
 	styleSpaceSel = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 	styleSpaceDim = lipgloss.NewStyle().Foreground(colorBarFg)
 	stylePaneSel = lipgloss.NewStyle().Foreground(colorAccent)

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -36,6 +36,7 @@ var (
 	styleBadgeInput  lipgloss.Style
 
 	// Sidebar.
+	styleSection   lipgloss.Style
 	styleSpaceSel  lipgloss.Style
 	styleSpaceDim  lipgloss.Style
 	stylePaneSel   lipgloss.Style
@@ -65,6 +66,7 @@ func rebuildStyles() {
 	styleBadgePrefix = lipgloss.NewStyle().Background(colorAlt).Foreground(colorInk).Bold(true)
 	styleBadgeInput = lipgloss.NewStyle().Background(colorGood).Foreground(colorInk).Bold(true)
 
+	styleSection = lipgloss.NewStyle().Foreground(colorMuted).Bold(true)
 	styleSpaceSel = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
 	styleSpaceDim = lipgloss.NewStyle().Foreground(colorBarFg).Bold(true)
 	stylePaneSel = lipgloss.NewStyle().Foreground(colorAccent)


### PR DESCRIPTION
This picks up #4 and the sidebar mockup that came out of the earlier UX discussion.

The old sidebar told two stories at once: panes lived under workspaces, but agents were also repeated in their own section. That made it harder to answer a simple question: ‘where does this pane belong?’ This change gives every pane one home and lets the hierarchy do the explaining.

## Screenshot

<img width="3420" height="2146" alt="omp-computer-155128422cf437e0" src="https://github.com/user-attachments/assets/1efdcf61-73ff-4e01-b2af-9044b1c73234" />

The existing behavior is still there: pane clicks activate the pane's owning tab, workspace dragging works across descendant rows, branch sync details stay beside the branch, and settings remain pinned at the bottom.

## Changelog

- Replaced the split `WORKSPACES` / `AGENTS` presentation with one workspace → tab → pane hierarchy under a single `WORKSPACES` heading.
- Removed duplicate agent rows.
- Unified shell and agent state glyphs while retaining state-aware colors.
- Reused the braille animation for agents that are actively working.
- Hid singleton tab rows while keeping multi-tab workspaces explicit.
- Extended the selected-workspace rail through all descendant rows.
- Added breathing room between the `WORKSPACES` heading and the first workspace.
- Updated sidebar hit testing, pane activation, context menus, and workspace drag targets for hierarchical rows.
- Updated README copy and regression coverage.

Closes #4