### PR TITLE
Fix update checks for Go pseudo-versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/term v0.2.1
 	github.com/mattn/go-runewidth v0.0.16
+	golang.org/x/mod v0.35.0
 	golang.org/x/sys v0.44.0
 )
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -8,10 +8,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"golang.org/x/mod/semver"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -109,40 +109,23 @@ func buildInfo(current, latest, url string) Info {
 	return info
 }
 
-// VersionLess returns a < b for dotted semver-ish tags like "0.0.4".
-// Non-numeric components compare as zero, which is fine for hrdx's
-// x.y.z-only scheme.
+// VersionLess reports whether a is an older semantic version than b.
+// Invalid versions fail closed so the updater never offers a downgrade.
 func VersionLess(a, b string) bool {
-	as := splitVersion(a)
-	bs := splitVersion(b)
-	for i := 0; i < 3; i++ {
-		av, bv := 0, 0
-		if i < len(as) {
-			av = as[i]
-		}
-		if i < len(bs) {
-			bv = bs[i]
-		}
-		if av != bv {
-			return av < bv
-		}
+	a = normalizedVersion(a)
+	b = normalizedVersion(b)
+	if !semver.IsValid(a) || !semver.IsValid(b) {
+		return false
 	}
-	return false
+	return semver.Compare(a, b) < 0
 }
 
-func splitVersion(s string) []int {
-	s = strings.TrimPrefix(s, "v")
-	// Strip build-metadata suffix like "(abc1234, 2026-04-18)".
-	if i := strings.IndexAny(s, " ("); i > 0 {
-		s = s[:i]
+func normalizedVersion(v string) string {
+	v = VersionOnly(v)
+	if !strings.HasPrefix(v, "v") {
+		v = "v" + v
 	}
-	parts := strings.Split(s, ".")
-	out := make([]int, 0, len(parts))
-	for _, p := range parts {
-		n, _ := strconv.Atoi(p)
-		out = append(out, n)
-	}
-	return out
+	return v
 }
 
 // VersionOnly strips build metadata appended to the version string, so

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -21,6 +21,10 @@ func TestVersionLess(t *testing.T) {
 		{"v0.0.1", "v0.0.2", true},
 		{"0.0.5 (abc1234, 2026-01-01)", "0.0.6", true},
 		{"1.0.0", "0.9.9", false},
+		{"0.0.21-0.20260809165004-9e3c28d4b65", "0.0.20", false},
+		{"0.0.21-0.20260809165004-9e3c28d4b65", "0.0.21", true},
+		{"0.0.20", "0.0.21-0.20260809165004-9e3c28d4b65", true},
+		{"not-a-version", "0.0.20", false},
 	}
 	for _, c := range cases {
 		if got := VersionLess(c.a, c.b); got != c.want {


### PR DESCRIPTION
## Summary
- replace the numeric-only version parser with `golang.org/x/mod/semver`
- compare Go pseudo-versions correctly and fail closed for invalid versions
- add regression coverage for the reported `0.0.21-0...` versus `0.0.20` downgrade notice

## Verification
- `go test ./internal/update`
- `go test ./...`
- built with `main.version=0.0.21-0.20260809165004-9e3c28d4b65` and ran `hrdx update --check`; it reported the build as up to date against `0.0.20`