### PR TITLE
Flag agent panes that finish work while unattended, and let harnesses report state via terminal title

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 hrdx is a experimental, minimal and lightweight terminal multiplexer built for the agent era: your projects as workspaces in a sidebar, tabs per workspace, and real terminal panes running [Codex CLI](https://learn.chatgpt.com/docs/codex/cli), [Claude Code](https://code.claude.com/docs/en/quickstart), [pi](https://www.pi.dev), [zot](https://www.zot.sh) or plain shells side by side. Kick off an agent in one project, switch to the next, and let the sidebar spinners tell you who is still working.
 
 - **Real terminals, not wrappers.** Every pane is a genuine PTY session with a full terminal emulator behind it. Agent TUIs run exactly as they do standalone: streaming, slash commands, sessions, mouse support, all of it. Panes present a clean terminal identity so capability-sniffing TUIs pick rendering paths that work inside a multiplexer, and `HRDX=1` lets tools detect they run inside hrdx.
-- **Everything in view.** The sidebar shows one hierarchy of workspaces, Git branches, and panes, adding tab rows only when a workspace has multiple tabs. Shell circles and agent diamonds expose pane type and state at a glance; an agent's icon becomes an animated braille spinner while it works.
+- **Everything in view.** The sidebar shows one hierarchy of workspaces, Git branches, and panes, adding tab rows only when a workspace has multiple tabs. Every pane has a shared status circle: agents become animated braille spinners while working, and an unfocused agent turns orange when it finishes. Focusing the pane acknowledges it and restores green.
 - **Feels like your terminal.** Scrollback, mouse selection with clipboard copy, drag-to-resize splits, drag-to-reorder workspaces, right-click context menus, and kitty keyboard protocol pass-through so even exotic chords like ctrl+1 reach your agent.
 - **Picks up where you left off.** Quit and relaunch: shells and agents keep running in a lightweight session holder and reattach exactly where they were, running commands and all. Workspaces, tabs, splits, and ratios come back too, and if a session is truly gone, agents resume their latest conversation from their own session store.
 - **Yours to tune.** A settings window (`ctrl+b ,` or the gear in the sidebar) lets you switch individual agents on or off, pick a notification sound for finished turns (including your own audio files), and change the color theme, with user themes as simple JSON files. All persisted. See [Themes](#themes).
@@ -177,7 +177,11 @@ Any agent CLI beyond the built-ins can be registered by dropping a `harness.json
     "resume": ["--restore-chat-history"],
     "busy": "Waiting for the model"
   },
-  { "kind": "goose" }
+  {
+    "kind": "goose",
+    "idle_title": "goose idle",
+    "attention_title": "goose waiting"
+  }
 ]
 ```
 
@@ -189,6 +193,15 @@ Any agent CLI beyond the built-ins can be registered by dropping a `harness.json
 | `resume` | Arguments that resume the latest session when a restored pane relaunches |
 | `resume_first` | Put the resume args before `args` (for subcommands like `resume --last`) |
 | `busy` | A substring visible on screen only while the harness is working; drives the busy spinner and the finish sound. Empty: braille spinner detection, like the built-ins |
+| `idle_title` | Terminal-title substring emitted when the harness is idle; overrides a stale visible spinner |
+| `attention_title` | Terminal-title substring emitted while waiting for user input; overrides the spinner and shows an orange dot when unfocused |
+
+Both title fields are optional and have no defaults, since every harness
+publishes its own markers. Leave them out and the harness is detected purely
+from the screen, exactly as `busy` describes. Set them when the harness keeps a
+spinner on screen while it is really idle or blocked on a prompt: a matching
+title always outranks the screen scrape. Check what your harness emits with
+`printf '\e]2;...\a'`-style OSC titles before picking a substring.
 
 ## Socket API
 
@@ -255,7 +268,7 @@ Values are ANSI 256 color numbers or `"#rrggbb"` strings.
 | `muted` | Secondary text, hints, idle pane names |
 | `faint` | Inactive pane borders, sidebar divider |
 | `good` | Running dots, input badge |
-| `busy` | Busy spinner |
+| `busy` | Busy spinner and completed-work attention dot |
 | `bad` | Errors, exited dots |
 | `bar_bg` / `bar_fg` | Header and footer bars |
 | `ink` | Text on accent backgrounds, tab bar strip |

--- a/internal/ui/agents.go
+++ b/internal/ui/agents.go
@@ -3,18 +3,21 @@ package ui
 import (
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 // agentSpec describes one supported coding agent CLI, built in or
 // registered as a custom harness from harness.json.
 type agentSpec struct {
-	kind        string
-	binary      string   // default binary name on $PATH
-	args        []string // extra launch args (custom harnesses)
-	resume      []string // args that resume the latest session
-	resumeFirst bool     // resume args are a subcommand and must come first
-	busyMatch   string   // screen substring visible while working; "" = spinner
-	custom      bool     // registered from harness.json
+	kind           string
+	binary         string   // default binary name on $PATH
+	args           []string // extra launch args (custom harnesses)
+	resume         []string // args that resume the latest session
+	resumeFirst    bool     // resume args are a subcommand and must come first
+	busyMatch      string   // screen substring visible while working; "" = spinner
+	idleTitle      string   // terminal-title substring that overrides stale busy UI
+	attentionTitle string   // title substring indicating the agent is waiting on the user
+	custom         bool     // registered from harness.json
 }
 
 // agentSpecs lists the supported agents in menu/cycle order
@@ -69,6 +72,28 @@ func (m Model) paneAgentKind(currentPane *pane) string {
 		if foreground == spec.binary || foreground == filepath.Base(m.config.binaryFor(spec.kind)) {
 			return spec.kind
 		}
+	}
+	return ""
+}
+
+// paneAgentTitleState interprets optional machine-readable title markers from
+// custom harnesses. Attention and idle titles override stale on-screen
+// spinners; an empty result leaves normal screen-based detection in charge.
+func (m Model) paneAgentTitleState(currentPane *pane) string {
+	if currentPane == nil || currentPane.term == nil || !currentPane.running {
+		return ""
+	}
+	kind := m.paneAgentKind(currentPane)
+	spec := agentByKind(kind)
+	if spec == nil {
+		return ""
+	}
+	title := currentPane.term.Title()
+	if spec.attentionTitle != "" && strings.Contains(title, spec.attentionTitle) {
+		return "attention"
+	}
+	if spec.idleTitle != "" && strings.Contains(title, spec.idleTitle) {
+		return "idle"
 	}
 	return ""
 }

--- a/internal/ui/find.go
+++ b/internal/ui/find.go
@@ -85,6 +85,7 @@ func (m *Model) jumpTo(chosen findCandidate) {
 	currentTab := owner.tab()
 	currentTab.selected = clampInt(chosen.paneIndex, 0, max(0, len(currentTab.panes)-1))
 	m.resizePanes(owner)
+	m.clearFocusedAttention()
 	m.closeFind()
 }
 

--- a/internal/ui/find_test.go
+++ b/internal/ui/find_test.go
@@ -26,6 +26,8 @@ func TestFuzzyMatch(t *testing.T) {
 
 func TestFindFiltersAndJumps(t *testing.T) {
 	model := newTestModel("/tmp/api", "/tmp/web")
+	target := model.spaces[1].tab().panes[0]
+	model.paneAttention[target.id] = true
 
 	updated, _ := model.updateKey(tea.KeyMsg{Type: tea.KeyCtrlB})
 	model = updated.(Model)
@@ -52,6 +54,9 @@ func TestFindFiltersAndJumps(t *testing.T) {
 	}
 	if model.mode != modeTerminal {
 		t.Fatalf("mode = %d, want modeTerminal after jump", model.mode)
+	}
+	if model.paneAttention[target.id] {
+		t.Fatal("find jump did not clear focused attention")
 	}
 }
 

--- a/internal/ui/harness.go
+++ b/internal/ui/harness.go
@@ -34,6 +34,10 @@ type harnessSpec struct {
 	// visible while it is working (e.g. "esc to interrupt"). When empty
 	// the braille spinner detection used for the built-ins applies.
 	Busy string `json:"busy,omitempty"`
+	// IdleTitle and AttentionTitle are terminal-title substrings emitted when
+	// work is done or blocked on user input. Either overrides a stale spinner.
+	IdleTitle      string `json:"idle_title,omitempty"`
+	AttentionTitle string `json:"attention_title,omitempty"`
 }
 
 // loadHarnesses reads harness.json from dir and registers every valid
@@ -83,14 +87,20 @@ func registerHarness(spec harnessSpec) error {
 	if binary == "" {
 		binary = kind
 	}
+	// Title markers are per-harness and have no sensible default: an unset
+	// marker simply leaves screen-based busy detection in charge.
+	idleTitle := strings.TrimSpace(spec.IdleTitle)
+	attentionTitle := strings.TrimSpace(spec.AttentionTitle)
 	entry := agentSpec{
-		kind:        kind,
-		binary:      binary,
-		args:        append([]string{}, spec.Args...),
-		resume:      append([]string{}, spec.Resume...),
-		resumeFirst: spec.ResumeFirst,
-		busyMatch:   spec.Busy,
-		custom:      true,
+		kind:           kind,
+		binary:         binary,
+		args:           append([]string{}, spec.Args...),
+		resume:         append([]string{}, spec.Resume...),
+		resumeFirst:    spec.ResumeFirst,
+		busyMatch:      spec.Busy,
+		idleTitle:      idleTitle,
+		attentionTitle: attentionTitle,
+		custom:         true,
 	}
 	for index := range agentSpecs {
 		if agentSpecs[index].kind == kind {

--- a/internal/ui/harness_test.go
+++ b/internal/ui/harness_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/patriceckhart/hrdx/internal/state"
+	"github.com/patriceckhart/hrdx/internal/term"
 )
 
 // resetHarnesses removes all custom entries registered by a test.
@@ -32,7 +33,8 @@ func TestLoadHarnessesRegistersCustomKinds(t *testing.T) {
 	defer resetHarnesses()
 	dir := writeHarnessFile(t, `[
 		{"kind": "aider", "binary": "aider", "args": ["--no-auto-commits"],
-		 "resume": ["--restore-chat-history"], "busy": "Waiting for the model"},
+		 "resume": ["--restore-chat-history"], "busy": "Waiting for the model",
+		 "idle_title": "aider idle", "attention_title": "aider waiting"},
 		{"kind": "goose"}
 	]`)
 
@@ -43,7 +45,8 @@ func TestLoadHarnessesRegistersCustomKinds(t *testing.T) {
 		t.Fatal("custom kinds should register as agents")
 	}
 	spec := agentByKind("aider")
-	if spec.binary != "aider" || len(spec.args) != 1 || spec.busyMatch != "Waiting for the model" {
+	if spec.binary != "aider" || len(spec.args) != 1 || spec.busyMatch != "Waiting for the model" ||
+		spec.idleTitle != "aider idle" || spec.attentionTitle != "aider waiting" {
 		t.Fatalf("aider spec = %+v", spec)
 	}
 	if !spec.custom {
@@ -51,6 +54,75 @@ func TestLoadHarnessesRegistersCustomKinds(t *testing.T) {
 	}
 	if agentByKind("goose").binary != "goose" {
 		t.Fatal("binary should default to kind")
+	}
+}
+
+// titledPane registers a custom harness and returns a model whose first
+// pane in the second space runs it, ready to be fed terminal output.
+func titledPane(t *testing.T, spec harnessSpec) (Model, *pane) {
+	t.Helper()
+	if err := registerHarness(spec); err != nil {
+		t.Fatal(err)
+	}
+	model := New(Config{DefaultAgent: spec.Kind, Shell: "/bin/sh"}, []string{"/tmp/api", "/tmp/web"}, "", state.State{})
+	target := model.spaces[1].tab().panes[0]
+	target.term = term.NewHolderPane(nil, 1, 80, 24)
+	target.running = true
+	return model, target
+}
+
+// A harness that declares no title markers must behave exactly as it did
+// before title states existed: screen detection stays in charge. Guards the
+// strings.Contains(title, "") trap, where an unset marker would match every
+// title and pin the pane to a permanent idle state.
+func TestHarnessWithoutTitleStatesFallsBackToScreen(t *testing.T) {
+	defer resetHarnesses()
+	model, target := titledPane(t, harnessSpec{Kind: "plain"})
+
+	if spec := agentByKind("plain"); spec.idleTitle != "" || spec.attentionTitle != "" {
+		t.Fatalf("unset title states = %q/%q, want both empty", spec.idleTitle, spec.attentionTitle)
+	}
+	target.term.Feed([]byte("\x1b]2;plain — some arbitrary title\x07⠋ Working"))
+	if state := model.paneAgentTitleState(target); state != "" {
+		t.Fatalf("title state = %q, want empty so the screen scrape decides", state)
+	}
+	if !model.paneBusy(target) {
+		t.Fatal("visible spinner must still read as busy when no titles are declared")
+	}
+	if got, want := model.sidebarPaneIcon(target), paneIconCell(styleDotBusy, spinnerFrames[0]); got != want {
+		t.Fatalf("icon = %q, want animated spinner %q", got, want)
+	}
+}
+
+func TestHarnessAttentionTitleOverridesVisibleSpinner(t *testing.T) {
+	defer resetHarnesses()
+	model, target := titledPane(t, harnessSpec{
+		Kind: "titled", IdleTitle: "[ready]", AttentionTitle: "[ask]",
+	})
+	target.term.Feed([]byte("\x1b]2;[ask] waiting for input\x07⠋ Working"))
+
+	if state := model.paneAgentTitleState(target); state != "attention" {
+		t.Fatalf("title state = %q, want attention", state)
+	}
+	if model.paneBusy(target) {
+		t.Fatal("attention title must override the stale visible spinner")
+	}
+	if got, want := model.sidebarPaneIcon(target), paneIconCell(styleDotBusy, "●"); got != want {
+		t.Fatalf("unfocused waiting icon = %q, want static orange circle %q", got, want)
+	}
+
+	model.selected = 1
+	if got, want := model.sidebarPaneIcon(target), paneIconCell(styleDotOn, "●"); got != want {
+		t.Fatalf("focused waiting icon = %q, want acknowledged green circle %q", got, want)
+	}
+
+	target.term.Feed([]byte("\x1b]2;[ready] waiting for prompt\x07"))
+	if state := model.paneAgentTitleState(target); state != "idle" || model.paneBusy(target) {
+		t.Fatalf("idle title state/busy = %q/%v, want idle/false", state, model.paneBusy(target))
+	}
+	target.term.Feed([]byte("\x1b]2;⠙ working\x07"))
+	if state := model.paneAgentTitleState(target); state != "" || !model.paneBusy(target) {
+		t.Fatalf("working title state/busy = %q/%v, want empty/true", state, model.paneBusy(target))
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1813,6 +1813,9 @@ func (m Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 				hit.pane >= 0 && hit.pane < len(target.tabs[hit.tab].panes) {
 				m.selected = hit.space
 				m.focusPane(target, target.tabs[hit.tab].panes[hit.pane])
+				// focusPane moves the active tab and that tab's selected
+				// pane, both of which belong to the saved state.
+				m.persist()
 			}
 		}
 	case "new":

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -153,7 +153,9 @@ type Model struct {
 	soundKind     string          // which sound: "ding" or a sounds.json entry
 	notifyOn      bool            // post a desktop notification on finish
 	themeName     string          // active color theme, "default" or a themes/ file
-	wasBusy       map[int]bool    // pane id -> spinner seen, for the finish sound
+	wasBusy       map[int]bool    // pane id -> spinner seen, for finish notifications
+	soundSeq      map[int]uint64  // invalidates stale agent-finish confirmations
+	paneAttention map[int]bool    // completed while unfocused; cleared only by focus
 	settingsTab   int             // active tab of the settings window
 	settingsIndex int             // selected row of the settings window
 	completions   []string
@@ -166,6 +168,7 @@ type Model struct {
 	events        *api.Broadcaster  // API event fan-out, nil-safe
 	holder        *holder.Client    // session holder connection, nil = local panes
 	blurredAt     time.Time         // when the terminal lost focus, for stale detection
+	appBlurred    bool              // terminal application currently lacks focus
 	cursorSink    *CursorSink       // publishes the hardware cursor position, nil-safe
 	prefixKeys    map[string]string // prefix key -> action, defaults plus keys.json
 	prefixTrigger string            // key that enters prefix mode from a live terminal
@@ -296,16 +299,26 @@ func (m *Model) flashInfo(text string) tea.Cmd {
 }
 
 // soundConfirmMsg fires a moment after a pane went from busy to idle; the
-// sound only plays when the pane is still idle then, so short redraw gaps
-// in the child's spinner do not ring the bell mid-turn.
-type soundConfirmMsg struct{ id int }
+// completion only counts when the pane is still idle then, so short redraw
+// gaps in the child's spinner do not create attention or ring mid-turn.
+type soundConfirmMsg struct {
+	id  int
+	seq uint64
+}
 
-// trackBusy watches one pane's busy state. On a busy -> idle transition it
-// schedules a debounced confirmation before playing the finish sound and
-// notifies API subscribers of the state change.
+func (m *Model) clearFocusedAttention() {
+	if focused := m.currentPane(); focused != nil {
+		delete(m.paneAttention, focused.id)
+	}
+}
+
+// trackBusy watches one pane's agent-busy state. On a busy -> idle
+// transition it schedules a debounced completion confirmation and notifies
+// API subscribers of the state change.
 func (m *Model) trackBusy(target *pane) tea.Cmd {
 	if m.paneBusy(target) {
 		if !m.wasBusy[target.id] {
+			m.soundSeq[target.id]++
 			m.publish(api.Event{Event: api.EventPaneBusyChanged,
 				Data: api.PaneEvent{Pane: target.id, Name: target.name, Kind: target.kind, Busy: true}})
 		}
@@ -318,11 +331,11 @@ func (m *Model) trackBusy(target *pane) tea.Cmd {
 	delete(m.wasBusy, target.id)
 	m.publish(api.Event{Event: api.EventPaneBusyChanged,
 		Data: api.PaneEvent{Pane: target.id, Name: target.name, Kind: target.kind, Busy: false}})
-	if !m.soundOn && !m.notifyOn {
-		return nil
-	}
-	id := target.id
-	return tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg { return soundConfirmMsg{id: id} })
+	m.soundSeq[target.id]++
+	id, seq := target.id, m.soundSeq[target.id]
+	return tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
+		return soundConfirmMsg{id: id, seq: seq}
+	})
 }
 
 // spinnerFrames matches zot's own braille spinner.
@@ -399,7 +412,8 @@ func New(config Config, paths []string, statePath string, saved state.State) Mod
 
 	model := Model{config: config, input: input, nextID: 1, statePath: statePath,
 		branches: map[string]branchInfo{}, disabled: map[string]bool{},
-		wasBusy: map[int]bool{}, soundOn: saved.Sound, status: harnessProblem,
+		wasBusy: map[int]bool{}, soundSeq: map[int]uint64{}, paneAttention: map[int]bool{},
+		soundOn: saved.Sound, status: harnessProblem,
 		soundKind: saved.SoundKind, notifyOn: saved.Notify, themeName: saved.Theme,
 		prefixKeys: buildPrefixKeys(keymapOverrides), keyOverrides: keymapOverrides}
 	model.prefixTrigger = model.primaryKey("prefix")
@@ -710,12 +724,16 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.FocusMsg:
+		m.appBlurred = false
+		m.clearFocusedAttention()
 		// Regaining focus after a long absence (system sleep, display
 		// reattach) can leave stale artifacts: the renderer's line cache
 		// no longer matches what is really on screen. Repaint everything
 		// then. Quick app switches skip the clear, which would otherwise
 		// flicker the whole UI on every alt-tab.
-		if m.blurredAt.IsZero() || time.Since(m.blurredAt) < staleAfter {
+		blurredAt := m.blurredAt
+		m.blurredAt = time.Time{}
+		if blurredAt.IsZero() || time.Since(blurredAt) < staleAfter {
 			return m, nil
 		}
 		for _, currentSpace := range m.spaces {
@@ -725,6 +743,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.BlurMsg:
 		m.blurredAt = time.Now()
+		m.appBlurred = true
 		return m, nil
 
 	case paneStartedMsg:
@@ -791,6 +810,9 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(sounds...)
 
 	case soundConfirmMsg:
+		if m.soundSeq[msg.id] != msg.seq {
+			return m, nil
+		}
 		target, _ := m.paneByID(msg.id)
 		if target == nil {
 			return m, nil
@@ -800,6 +822,9 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			// finished turn. trackBusy re-arms the transition.
 			m.wasBusy[msg.id] = true
 			return m, nil
+		}
+		if focused := m.currentPane(); m.appBlurred || focused == nil || focused.id != target.id {
+			m.paneAttention[target.id] = true
 		}
 		if m.soundOn {
 			playSound(m.soundKind)
@@ -1521,6 +1546,7 @@ func (m Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			if index >= 0 {
 				currentSpace.active = index
 				m.resizePanes(currentSpace)
+				m.clearFocusedAttention()
 				m.openTabMenu(currentSpace.tabs[index], rect{x: msg.X, y: 1})
 			}
 			return m, nil
@@ -1535,6 +1561,7 @@ func (m Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		if index >= 0 {
 			currentSpace.active = index
 			m.resizePanes(currentSpace)
+			m.clearFocusedAttention()
 			m.persist()
 		}
 		return m, nil
@@ -1747,6 +1774,7 @@ func (m Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		descendant := hit.kind == "space" || hit.kind == "tab" || hit.kind == "pane"
 		if descendant && hit.space >= 0 && hit.space < len(m.spaces) {
 			m.selected = hit.space
+			m.clearFocusedAttention()
 			m.openSpaceMenu(m.spaces[hit.space], rect{x: msg.X, y: msg.Y - 1})
 		}
 		return m, nil
@@ -1761,6 +1789,7 @@ func (m Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	case "space":
 		if hit.space >= 0 && hit.space < len(m.spaces) {
 			m.selected = hit.space
+			m.clearFocusedAttention()
 			// Arm a reorder drag; a plain click releases without motion
 			// and leaves the order untouched.
 			m.dragSpace = m.spaces[hit.space]
@@ -1773,6 +1802,7 @@ func (m Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 				m.selected = hit.space
 				target.active = hit.tab
 				m.resizePanes(target)
+				m.clearFocusedAttention()
 				m.persist()
 			}
 		}
@@ -1839,6 +1869,7 @@ func (m *Model) focusPane(owner *space, target *pane) {
 			if current == target {
 				owner.active = tabIndex
 				currentTab.selected = index
+				m.clearFocusedAttention()
 				return
 			}
 		}
@@ -1861,8 +1892,18 @@ type sidebarRow struct {
 // are detected by the braille spinner their TUIs render during a turn;
 // custom harnesses can declare a busy substring instead.
 func (m Model) paneBusy(currentPane *pane) bool {
+	return m.paneBusyWithTitle(currentPane, m.paneAgentTitleState(currentPane))
+}
+
+// paneBusyWithTitle is paneBusy with the title state already resolved, so the
+// sidebar can share one lookup between the busy check and the attention dot.
+// Any non-empty title state is authoritative and outranks the screen scrape.
+func (m Model) paneBusyWithTitle(currentPane *pane, titleState string) bool {
 	kind := m.paneAgentKind(currentPane)
 	if kind == "" || !currentPane.running || currentPane.term == nil {
+		return false
+	}
+	if titleState != "" {
 		return false
 	}
 	if spec := agentByKind(kind); spec != nil && spec.busyMatch != "" {
@@ -1875,10 +1916,17 @@ func (m Model) paneBusy(currentPane *pane) bool {
 // color and animation expose pane state. Agents animate only while active;
 // an idle agent process stays a dot.
 func (m Model) sidebarPaneIcon(currentPane *pane) string {
+	titleState := m.paneAgentTitleState(currentPane)
+	attention := m.paneAttention[currentPane.id]
+	if titleState == "attention" {
+		focused := m.currentPane()
+		attention = attention || m.appBlurred || focused == nil || focused != currentPane
+	}
 	return paneTypeStateIcon(
 		currentPane,
 		m.paneAgentKind(currentPane) != "",
-		m.paneBusy(currentPane),
+		m.paneBusyWithTitle(currentPane, titleState),
+		attention,
 		m.spinFrame,
 	)
 }
@@ -1890,13 +1938,15 @@ func paneIconCell(style lipgloss.Style, glyph string) string {
 	return style.Render(glyph)
 }
 
-func paneTypeStateIcon(currentPane *pane, agent, busy bool, frame int) string {
+func paneTypeStateIcon(currentPane *pane, agent, busy, attention bool, frame int) string {
 	runningGlyph, stoppedGlyph := "●", "○"
 	switch {
 	case currentPane.failure != "":
 		return paneIconCell(styleDotOff, stoppedGlyph)
 	case agent && busy:
 		return paneIconCell(styleDotBusy, spinnerFrames[frame%len(spinnerFrames)])
+	case currentPane.running && attention:
+		return paneIconCell(styleDotBusy, runningGlyph)
 	case currentPane.running:
 		return paneIconCell(styleDotOn, runningGlyph)
 	case currentPane.term == nil:
@@ -2653,6 +2703,7 @@ func (m *Model) selectSpace(delta int) {
 	if len(m.spaces) > 0 {
 		count := len(m.spaces)
 		m.selected = (m.selected + delta + count) % count
+		m.clearFocusedAttention()
 	}
 }
 
@@ -2664,6 +2715,7 @@ func (m *Model) selectTab(delta int) {
 	count := len(currentSpace.tabs)
 	currentSpace.active = (currentSpace.active + delta + count) % count
 	m.resizePanes(currentSpace)
+	m.clearFocusedAttention()
 }
 
 // cyclePane moves focus through the active tab's panes in layout order.
@@ -2694,6 +2746,7 @@ func (m *Model) cyclePane(delta int) {
 	for index, target := range currentTab.panes {
 		if target == next {
 			currentTab.selected = index
+			m.clearFocusedAttention()
 			return
 		}
 	}
@@ -2728,6 +2781,9 @@ func (m *Model) removePane(owner *space, target *pane) {
 		if index < 0 {
 			continue
 		}
+		delete(m.wasBusy, target.id)
+		delete(m.soundSeq, target.id)
+		delete(m.paneAttention, target.id)
 		if target.term != nil {
 			target.term.Close()
 		}
@@ -2741,6 +2797,7 @@ func (m *Model) removePane(owner *space, target *pane) {
 			m.closeTab(owner, currentTab)
 		}
 		m.resizePanes(owner)
+		m.clearFocusedAttention()
 		m.persist()
 		return
 	}
@@ -2748,6 +2805,9 @@ func (m *Model) removePane(owner *space, target *pane) {
 
 func (m *Model) closeTab(owner *space, target *tab) {
 	for _, currentPane := range target.panes {
+		delete(m.wasBusy, currentPane.id)
+		delete(m.soundSeq, currentPane.id)
+		delete(m.paneAttention, currentPane.id)
 		if currentPane.term != nil {
 			currentPane.term.Close()
 		}
@@ -2759,6 +2819,7 @@ func (m *Model) closeTab(owner *space, target *tab) {
 		}
 	}
 	owner.active = clampInt(owner.active, 0, max(0, len(owner.tabs)-1))
+	m.clearFocusedAttention()
 }
 
 func (m *Model) closeCurrentSpace() {
@@ -2767,6 +2828,9 @@ func (m *Model) closeCurrentSpace() {
 	}
 	for _, currentTab := range m.spaces[m.selected].tabs {
 		for _, currentPane := range currentTab.panes {
+			delete(m.wasBusy, currentPane.id)
+			delete(m.soundSeq, currentPane.id)
+			delete(m.paneAttention, currentPane.id)
 			if currentPane.term != nil {
 				currentPane.term.Close()
 			}
@@ -2776,6 +2840,7 @@ func (m *Model) closeCurrentSpace() {
 	if m.selected >= len(m.spaces) {
 		m.selected = max(0, len(m.spaces)-1)
 	}
+	m.clearFocusedAttention()
 	m.persist()
 }
 

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -182,17 +182,23 @@ func TestSidebarPaneRowsUseSharedShellAndAgentSymbols(t *testing.T) {
 	}
 
 	shell := &pane{kind: "shell", running: true}
-	if got, want := paneTypeStateIcon(shell, false, false, 0), paneIconCell(styleDotOn, "●"); got != want {
+	if got, want := paneTypeStateIcon(shell, false, false, false, 0), paneIconCell(styleDotOn, "●"); got != want {
 		t.Fatalf("running shell icon = %q, want %q", got, want)
 	}
 	agent := &pane{kind: "zot", running: true}
-	if got, want := paneTypeStateIcon(agent, true, false, 0), paneIconCell(styleDotOn, "●"); got != want {
+	if got, want := paneTypeStateIcon(agent, true, false, false, 0), paneIconCell(styleDotOn, "●"); got != want {
 		t.Fatalf("idle agent icon = %q, want shared shell icon %q", got, want)
 	}
-	if got, want := paneTypeStateIcon(agent, true, true, 0), paneIconCell(styleDotBusy, spinnerFrames[0]); got != want {
+	if got, want := paneTypeStateIcon(agent, true, true, false, 0), paneIconCell(styleDotBusy, spinnerFrames[0]); got != want {
 		t.Fatalf("busy agent icon = %q, want animated spinner %q", got, want)
 	}
-	if width := lipgloss.Width(paneTypeStateIcon(agent, true, false, 0)); width != 2 {
+	if got, want := paneTypeStateIcon(agent, true, false, true, 0), paneIconCell(styleDotBusy, "●"); got != want {
+		t.Fatalf("completed agent icon = %q, want static orange circle %q", got, want)
+	}
+	if got, want := paneTypeStateIcon(agent, true, true, true, 0), paneIconCell(styleDotBusy, spinnerFrames[0]); got != want {
+		t.Fatalf("busy attentive agent icon = %q, want spinner to take precedence %q", got, want)
+	}
+	if width := lipgloss.Width(paneTypeStateIcon(agent, true, false, false, 0)); width != 2 {
 		t.Fatalf("agent icon width = %d, want fixed two-cell column", width)
 	}
 }
@@ -269,6 +275,8 @@ func TestMouseSelectsSidebarTabAndPane(t *testing.T) {
 	currentSpace := model.spaces[0]
 	model.addTab(currentSpace, "shell")
 	currentSpace.active = 0
+	target := currentSpace.tabs[1].panes[0]
+	model.paneAttention[target.id] = true
 
 	activeTab := model.sidebarRows()[4].label
 	if !strings.Contains(activeTab, styleSpaceSel.Render("▸")) || !strings.Contains(activeTab, styleSpaceSel.Render("1")) {
@@ -282,13 +290,20 @@ func TestMouseSelectsSidebarTabAndPane(t *testing.T) {
 	if got.spaces[0].active != 1 {
 		t.Fatalf("active tab = %d, want 1 after clicking tab row", got.spaces[0].active)
 	}
+	if got.paneAttention[target.id] {
+		t.Fatal("clicking tab row did not clear focused attention")
+	}
 
 	got.spaces[0].active = 0
+	got.paneAttention[target.id] = true
 	updated, _ = got.updateMouse(tea.MouseMsg{X: 7, Y: 8, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
 	got = updated.(Model)
 	if got.spaces[0].active != 1 || got.spaces[0].tabs[1].selected != 0 {
 		t.Fatalf("active tab/pane = %d/%d, want 1/0 after clicking pane row",
 			got.spaces[0].active, got.spaces[0].tabs[1].selected)
+	}
+	if got.paneAttention[target.id] {
+		t.Fatal("clicking pane row did not clear focused attention")
 	}
 }
 
@@ -600,12 +615,16 @@ func TestCloseCurrentPaneClamps(t *testing.T) {
 	if currentTab.selected != 1 {
 		t.Fatalf("selected pane = %d, want 1", currentTab.selected)
 	}
+	model.paneAttention[currentTab.panes[0].id] = true
 	model.closeCurrentPane()
 	if len(currentTab.panes) != 1 || currentTab.selected != 0 {
 		t.Fatalf("panes = %d selected = %d, want 1/0", len(currentTab.panes), currentTab.selected)
 	}
 	if !strings.HasPrefix(currentTab.panes[0].name, "zot") {
 		t.Fatalf("remaining pane = %q, want the zot pane", currentTab.panes[0].name)
+	}
+	if model.paneAttention[currentTab.panes[0].id] {
+		t.Fatal("newly focused sibling retained attention after pane close")
 	}
 }
 
@@ -642,5 +661,64 @@ func TestGitBranchDetection(t *testing.T) {
 	}
 	if branch := readGitBranch(dir); branch != "0123456" {
 		t.Fatalf("detached branch = %q, want short hash", branch)
+	}
+}
+
+func TestBlurredAgentFinishGetsAttentionUntilAppFocusReturns(t *testing.T) {
+	model := newTestModel("/tmp/api")
+	target := model.currentPane()
+	updated, _ := model.Update(tea.BlurMsg{})
+	model = updated.(Model)
+	model.soundSeq[target.id] = 1
+	updated, _ = model.Update(soundConfirmMsg{id: target.id, seq: 1})
+	model = updated.(Model)
+	if !model.paneAttention[target.id] {
+		t.Fatal("agent completion while application was blurred did not set attention")
+	}
+
+	updated, _ = model.Update(tea.FocusMsg{})
+	model = updated.(Model)
+	if model.paneAttention[target.id] {
+		t.Fatal("application focus did not acknowledge the focused pane")
+	}
+}
+
+func TestFocusNavigationClearsAttention(t *testing.T) {
+	t.Run("tab", func(t *testing.T) {
+		model := newTestModel("/tmp/api")
+		owner := model.currentSpace()
+		first := owner.tab().panes[0]
+		model.addTab(owner, "shell")
+		model.paneAttention[first.id] = true
+		model.selectTab(-1)
+		if model.paneAttention[first.id] {
+			t.Fatal("tab selection did not clear attention")
+		}
+	})
+
+	t.Run("pane", func(t *testing.T) {
+		model := newTestModel("/tmp/api")
+		owner := model.currentSpace()
+		first := owner.tab().panes[0]
+		model.addPane(owner, "shell", true)
+		model.paneAttention[first.id] = true
+		model.cyclePane(1)
+		if model.paneAttention[first.id] {
+			t.Fatal("pane cycling did not clear attention")
+		}
+	})
+}
+
+func TestRemovePaneClearsCompletionState(t *testing.T) {
+	model := newTestModel("/tmp/api")
+	owner := model.currentSpace()
+	target := model.addPane(owner, "shell", true)
+	model.wasBusy[target.id] = true
+	model.soundSeq[target.id] = 2
+	model.paneAttention[target.id] = true
+
+	model.removePane(owner, target)
+	if model.wasBusy[target.id] || model.soundSeq[target.id] != 0 || model.paneAttention[target.id] {
+		t.Fatal("removed pane retained completion state")
 	}
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -304,6 +305,31 @@ func TestMouseSelectsSidebarTabAndPane(t *testing.T) {
 	}
 	if got.paneAttention[target.id] {
 		t.Fatal("clicking pane row did not clear focused attention")
+	}
+}
+
+func TestMouseSidebarPaneClickPersists(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	model := New(Config{Shell: "/bin/sh"}, []string{"/tmp/api"}, statePath, state.State{})
+	model.width, model.height = 120, 35
+	currentSpace := model.spaces[0]
+	model.addTab(currentSpace, "shell")
+	currentSpace.active = 0
+
+	// Sidebar rows: 3 workspace, 4 tab 1, 5 pane, 6 tab 2, 7 pane.
+	// Screen Y is sidebar row + 1, so Y=8 is tab 2's pane row.
+	model.updateMouse(tea.MouseMsg{X: 7, Y: 8, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+
+	saved, err := state.Load(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if len(saved.Workspaces) != 1 {
+		t.Fatalf("saved workspaces = %d, want 1", len(saved.Workspaces))
+	}
+	if saved.Workspaces[0].Active != 1 {
+		t.Fatalf("saved active tab = %d, want 1 after clicking a pane on another tab",
+			saved.Workspaces[0].Active)
 	}
 }
 

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -89,10 +89,44 @@ func TestTrackBusyDebouncesSound(t *testing.T) {
 		t.Fatal("transition should consume the busy mark")
 	}
 
-	// With sound off nothing is scheduled.
+	// Attention still needs a debounced completion when sound is off.
 	model.soundOn = false
 	model.wasBusy[target.id] = true
-	if cmd := model.trackBusy(target); cmd != nil {
-		t.Fatal("sound off must not schedule a confirm tick")
+	if cmd := model.trackBusy(target); cmd == nil {
+		t.Fatal("sound off must still schedule completion confirmation")
+	}
+}
+
+func TestAgentFinishSetsAttentionWhenUnfocused(t *testing.T) {
+	model := newTestModel("/tmp/api", "/tmp/web")
+	target := model.spaces[1].tab().panes[0]
+	model.wasBusy[target.id] = true
+	if cmd := model.trackBusy(target); cmd == nil {
+		t.Fatal("busy -> idle should schedule confirmation")
+	}
+
+	updated, _ := model.Update(soundConfirmMsg{id: target.id, seq: model.soundSeq[target.id]})
+	model = updated.(Model)
+	if !model.paneAttention[target.id] {
+		t.Fatal("confirmed unfocused agent finish did not set attention")
+	}
+}
+
+func TestFocusedAndStaleAgentFinishDoNotSetAttention(t *testing.T) {
+	model := newTestModel("/tmp/api", "/tmp/web")
+	focused := model.spaces[0].tab().panes[0]
+	model.soundSeq[focused.id] = 1
+	updated, _ := model.Update(soundConfirmMsg{id: focused.id, seq: 1})
+	model = updated.(Model)
+	if model.paneAttention[focused.id] {
+		t.Fatal("focused agent finish set attention")
+	}
+
+	target := model.spaces[1].tab().panes[0]
+	model.soundSeq[target.id] = 2
+	updated, _ = model.Update(soundConfirmMsg{id: target.id, seq: 1})
+	model = updated.(Model)
+	if model.paneAttention[target.id] {
+		t.Fatal("stale finish timer set attention")
 	}
 }

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -25,7 +25,7 @@ type themeColors struct {
 	Muted  json.RawMessage `json:"muted,omitempty"`  // secondary text
 	Faint  json.RawMessage `json:"faint,omitempty"`  // inactive borders
 	Good   json.RawMessage `json:"good,omitempty"`   // running dots, ok badge
-	Busy   json.RawMessage `json:"busy,omitempty"`   // busy spinner
+	Busy   json.RawMessage `json:"busy,omitempty"`   // busy spinner, completed-work dot
 	Bad    json.RawMessage `json:"bad,omitempty"`    // errors, exited dots
 	BarBg  json.RawMessage `json:"bar_bg,omitempty"` // header/footer background
 	BarFg  json.RawMessage `json:"bar_fg,omitempty"` // header/footer text


### PR DESCRIPTION
Two related changes to how the sidebar reports what an agent pane is doing.

## 1. Panes that finish work while you are away keep an attention dot

A busy to idle transition that is confirmed while the pane is *unattended*
latches an attention state on that pane, drawn as a static orange dot. It only clears when you actually
focus that pane. "Unattended" covers both cases — the pane is not the focused
one, or the terminal application itself does not have focus (`tea.FocusMsg` /
`tea.BlurMsg`).

## 2. Harnesses can declare idle / attention terminal titles

Busy detection has always worked by scraping the child TUI's braille spinner
off the screen. That misreads any harness which leaves a spinner visible while
it is actually blocked on a prompt — the pane spins forever and never reports
finishing, so it never earns an attention dot either.

Harnesses can now publish their state through the terminal title instead, which
is machine-readable rather than inferred. Two optional fields in `harness.json`:

| Field | Meaning |
| --- | --- |
| `idle_title` | Title substring emitted when the harness is idle |
| `attention_title` | Title substring emitted while it waits on the user |

### Both fields are optional and have no defaults

Every harness publishes different markers, so there is nothing sensible to
guess. Omit them and behaviour is byte-for-byte what it is today: the screen
scrape decides, exactly as `busy` describes. This is covered by
`TestHarnessWithoutTitleStatesFallsBackToScreen`, which also guards the
`strings.Contains(title, "")` trap — an unmatched empty marker would otherwise
be a substring of every title and pin every pane to a permanent idle state.

### Example: OMP

OMP is a good illustration of the problem, because its todo/ask UI keeps a
braille spinner on screen while it is waiting for you. It publishes stable OSC
title states, so it configures cleanly:

```json
{
  "kind": "omp",
  "binary": "omp",
  "resume": ["--continue"],
  "idle_title": "π >",
  "attention_title": "π !"
}
```

With that in place an OMP pane sitting at its ask-prompt stops spinning and
shows the orange attention dot until you switch to it. Any harness that emits
comparable markers works the same way; to find yours, watch the OSC title your
harness sets (`\e]2;...\a`) while it changes state.

## Notes for review

- The attention dot reuses the existing `busy` theme colour rather than adding a
  new one, so it stays themeable with no config migration. It is distinguished
  from "running" by colour alone, which is the one deliberate trade-off here —
  happy to switch to a distinct glyph if you would rather it not depend on
  colour.
- `paneBusy` gained a `paneBusyWithTitle` variant so the sidebar resolves the
  title state once per frame and shares it between the busy check and the
  attention dot, instead of looking it up twice.
- README documents both fields and the no-default behaviour.

