### PR TITLE
Restore shell shortcuts after full-screen apps exit

### DIFF
--- a/internal/term/pane.go
+++ b/internal/term/pane.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -28,17 +29,19 @@ type SessionHost interface {
 // is either owned locally (pty/cmd) or lives in the session holder
 // (host/session), in which case output arrives via Feed.
 type Pane struct {
-	mu           sync.Mutex
-	vt           vt.Terminal
-	pty          pty.Pty
-	ptyCloseOnce sync.Once
-	cmd          *pty.Cmd
-	host         SessionHost
-	session      int64
-	updates      chan struct{}
-	exited       bool
-	kittyKeys    bool
-	scanTail     []byte
+	mu              sync.Mutex
+	vt              vt.Terminal
+	pty             pty.Pty
+	ptyCloseOnce    sync.Once
+	cmd             *pty.Cmd
+	host            SessionHost
+	session         int64
+	updates         chan struct{}
+	exited          bool
+	keyboardMode    [2]keyboardProtocolMode // shell and full-screen app views
+	keyboardAlt     bool
+	modifyOtherKeys bool // xterm fallback shared by both views
+	scanTail        []byte
 
 	// Foreground process caches. Mouse capture uses its own short-lived
 	// cache so an exited TUI cannot leave mouse reporting active in a shell.
@@ -254,22 +257,200 @@ func (p *Pane) writeOutput(data []byte) {
 	p.scrollOffset = min(limit, p.scrollOffset+int(after-before))
 }
 
-// scanKeyboardProtocol watches the output stream for kitty keyboard
-// protocol pushes and pops so the multiplexer knows whether this child
-// understands CSI-u key encodings. Called with p.mu held.
+// keyboardProtocolMode is the Kitty keyboard setting for one terminal view.
+// A pane has one view for its shell and another for full-screen apps, and Kitty
+// requires each view to keep its own small push/pop stack.
+type keyboardProtocolMode struct {
+	kittyFlags int
+	kittyStack []int
+}
+
+const (
+	kittyKeyboardStackLimit = 8
+	keyboardScanTailLimit   = 4096
+)
+
+// scanKeyboardProtocol follows keyboard-related escape sequences in pane
+// output. It uses a small streaming parser because a PTY can split a sequence
+// across reads. Called with p.mu held.
 func (p *Pane) scanKeyboardProtocol(chunk []byte) {
-	data := append(p.scanTail, chunk...)
-	if bytes.Contains(data, []byte("\x1b[>1u")) || bytes.Contains(data, []byte("\x1b[>4;2m")) {
-		p.kittyKeys = true
+	if len(chunk) == 0 && len(p.scanTail) == 0 {
+		return
 	}
-	if bytes.Contains(data, []byte("\x1b[<u")) {
-		p.kittyKeys = false
+	data := make([]byte, 0, len(p.scanTail)+len(chunk))
+	data = append(data, p.scanTail...)
+	data = append(data, chunk...)
+	p.scanTail = p.scanTail[:0]
+
+	for offset := 0; offset < len(data); {
+		if data[offset] != '\x1b' {
+			offset++
+			continue
+		}
+		start := offset
+		if offset+1 == len(data) {
+			p.keepKeyboardScanTail(data[start:])
+			return
+		}
+
+		switch data[offset+1] {
+		case 'c': // RIS: reset the terminal, including keyboard modes
+			p.resetKeyboardProtocol()
+			offset += 2
+		case '[':
+			final := offset + 2
+			for {
+				if final == len(data) {
+					p.keepKeyboardScanTail(data[start:])
+					return
+				}
+				char := data[final]
+				switch {
+				case char == '\x1b':
+					// ESC cancels an incomplete CSI and starts a new sequence.
+					offset = final
+				case char == 0x18 || char == 0x1a:
+					// CAN and SUB cancel an incomplete CSI.
+					offset = final + 1
+				case char >= 0x40 && char <= 0x7e:
+					p.applyKeyboardCSI(data[offset+2:final], char)
+					offset = final + 1
+				case char < 0x20 || char > 0x3f:
+					// Invalid CSI byte: discard this sequence and recover.
+					offset = final + 1
+				default:
+					final++
+					continue
+				}
+				break
+			}
+		case '\x1b':
+			// The second ESC starts a replacement sequence.
+			offset++
+		default:
+			offset += 2
+		}
 	}
-	// Keep a short tail so sequences split across reads are still seen.
-	if len(data) > 8 {
-		data = data[len(data)-8:]
+}
+
+func (p *Pane) keepKeyboardScanTail(data []byte) {
+	if len(data) <= keyboardScanTailLimit {
+		p.scanTail = append(p.scanTail, data...)
 	}
-	p.scanTail = append(p.scanTail[:0], data...)
+}
+
+func (p *Pane) resetKeyboardProtocol() {
+	p.keyboardMode = [2]keyboardProtocolMode{}
+	p.keyboardAlt = false
+	p.modifyOtherKeys = false
+}
+
+func parseKeyboardParams(body []byte) ([]int, bool) {
+	if len(body) == 0 {
+		return nil, true
+	}
+	fields := strings.Split(string(body), ";")
+	values := make([]int, len(fields))
+	for index, field := range fields {
+		if field == "" {
+			continue
+		}
+		value, err := strconv.Atoi(field)
+		if err != nil || value < 0 {
+			return nil, false
+		}
+		values[index] = value
+	}
+	return values, true
+}
+
+func (p *Pane) applyKeyboardCSI(body []byte, final byte) {
+	// These sequences switch between the shell view and the view used by
+	// full-screen apps. Kitty gives each view its own keyboard stack.
+	if (final == 'h' || final == 'l') && len(body) > 1 && body[0] == '?' {
+		for _, field := range strings.Split(string(body[1:]), ";") {
+			value, err := strconv.Atoi(field)
+			if err == nil && (value == 47 || value == 1047 || value == 1049) {
+				p.keyboardAlt = final == 'h'
+			}
+		}
+		return
+	}
+
+	mode := &p.keyboardMode[0]
+	if p.keyboardAlt {
+		mode = &p.keyboardMode[1]
+	}
+
+	if final == 'u' && len(body) > 0 {
+		marker := body[0]
+		if marker != '>' && marker != '=' && marker != '<' {
+			return // a key report or query, not a mode change
+		}
+		params, ok := parseKeyboardParams(body[1:])
+		if !ok {
+			return
+		}
+		value := 0
+		if len(params) > 0 {
+			value = params[0]
+		}
+		switch marker {
+		case '>': // save the current flags and use the requested flags
+			if len(mode.kittyStack) == kittyKeyboardStackLimit {
+				copy(mode.kittyStack, mode.kittyStack[1:])
+				mode.kittyStack = mode.kittyStack[:kittyKeyboardStackLimit-1]
+			}
+			mode.kittyStack = append(mode.kittyStack, mode.kittyFlags)
+			mode.kittyFlags = value
+		case '=': // replace, add, or remove selected flags
+			how := 1
+			if len(params) > 1 {
+				how = params[1]
+			}
+			switch how {
+			case 1:
+				mode.kittyFlags = value
+			case 2:
+				mode.kittyFlags |= value
+			case 3:
+				mode.kittyFlags &^= value
+			}
+		case '<': // restore one saved mode by default
+			count := value
+			if count == 0 {
+				count = 1
+			}
+			for range count {
+				if len(mode.kittyStack) == 0 {
+					mode.kittyFlags = 0
+					break
+				}
+				last := len(mode.kittyStack) - 1
+				mode.kittyFlags = mode.kittyStack[last]
+				mode.kittyStack = mode.kittyStack[:last]
+			}
+		}
+		return
+	}
+
+	// Xterm's fallback setting belongs to the whole terminal rather than one
+	// view. CSI > 4 ; 2 m enables it; CSI > 4 m disables it.
+	if final == 'm' && len(body) > 0 && body[0] == '>' {
+		fields := strings.Split(string(body[1:]), ";")
+		if fields[0] != "4" {
+			return
+		}
+		if len(fields) == 1 {
+			p.modifyOtherKeys = false
+			return
+		}
+		if len(fields) != 2 {
+			return
+		}
+		value, err := strconv.Atoi(fields[1])
+		p.modifyOtherKeys = err == nil && value == 2
+	}
 }
 
 // fgCacheTTL bounds how often ForegroundCommand does the ioctl + process
@@ -319,7 +500,11 @@ func (p *Pane) ForegroundCommand() string {
 func (p *Pane) KittyKeys() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.kittyKeys
+	index := 0
+	if p.keyboardAlt {
+		index = 1
+	}
+	return p.keyboardMode[index].kittyFlags != 0 || p.modifyOtherKeys
 }
 
 // HasSpinner reports whether the visible screen contains a braille spinner

--- a/internal/term/pane.go
+++ b/internal/term/pane.go
@@ -29,19 +29,20 @@ type SessionHost interface {
 // is either owned locally (pty/cmd) or lives in the session holder
 // (host/session), in which case output arrives via Feed.
 type Pane struct {
-	mu              sync.Mutex
-	vt              vt.Terminal
-	pty             pty.Pty
-	ptyCloseOnce    sync.Once
-	cmd             *pty.Cmd
-	host            SessionHost
-	session         int64
-	updates         chan struct{}
-	exited          bool
-	keyboardMode    [2]keyboardProtocolMode // shell and full-screen app views
-	keyboardAlt     bool
-	modifyOtherKeys bool // xterm fallback shared by both views
-	scanTail        []byte
+	mu                  sync.Mutex
+	vt                  vt.Terminal
+	pty                 pty.Pty
+	ptyCloseOnce        sync.Once
+	cmd                 *pty.Cmd
+	host                SessionHost
+	session             int64
+	updates             chan struct{}
+	exited              bool
+	keyboardMode        [2]keyboardProtocolMode // shell and full-screen app views
+	keyboardAlt         bool
+	modifyOtherKeys     bool // active xterm fallback setting
+	modifyOtherKeysMain bool // main-screen setting saved while alt screen is active
+	scanTail            []byte
 
 	// Foreground process caches. Mouse capture uses its own short-lived
 	// cache so an exited TUI cannot leave mouse reporting active in a shell.
@@ -343,6 +344,7 @@ func (p *Pane) resetKeyboardProtocol() {
 	p.keyboardMode = [2]keyboardProtocolMode{}
 	p.keyboardAlt = false
 	p.modifyOtherKeys = false
+	p.modifyOtherKeysMain = false
 }
 
 func parseKeyboardParams(body []byte) ([]int, bool) {
@@ -370,9 +372,23 @@ func (p *Pane) applyKeyboardCSI(body []byte, final byte) {
 	if (final == 'h' || final == 'l') && len(body) > 1 && body[0] == '?' {
 		for _, field := range strings.Split(string(body[1:]), ";") {
 			value, err := strconv.Atoi(field)
-			if err == nil && (value == 47 || value == 1047 || value == 1049) {
-				p.keyboardAlt = final == 'h'
+			if err != nil || (value != 47 && value != 1047 && value != 1049) {
+				continue
 			}
+			alt := final == 'h'
+			if alt == p.keyboardAlt {
+				continue
+			}
+			if alt {
+				// modifyOtherKeys is global in xterm, so the alternate screen
+				// inherits it. Save the shell's value before the child changes it.
+				p.modifyOtherKeysMain = p.modifyOtherKeys
+			} else {
+				// A full-screen child may exit without resetting the global xterm
+				// fallback. Restore the value that belonged to the shell.
+				p.modifyOtherKeys = p.modifyOtherKeysMain
+			}
+			p.keyboardAlt = alt
 		}
 		return
 	}

--- a/internal/term/pane_test.go
+++ b/internal/term/pane_test.go
@@ -252,6 +252,127 @@ func TestShellCommandNames(t *testing.T) {
 	}
 }
 
+func TestKittyKeyboardModeDoesNotLeakOutOfAltScreen(t *testing.T) {
+	pane := NewHolderPane(nil, 1, 40, 6)
+
+	// Full-screen children enable kitty keyboard reporting on the alternate
+	// screen. Its keyboard-mode stack is separate from the shell's main-screen
+	// stack, so leaving the alternate screen must restore the shell's mode even
+	// when the child exits without an explicit kitty pop sequence.
+	pane.Feed([]byte("\x1b[?1049h"))
+	pane.Feed([]byte("\x1b[>1u"))
+	if !pane.KittyKeys() {
+		t.Fatal("kitty keyboard mode was not detected on the alternate screen")
+	}
+
+	pane.Feed([]byte("\x1b[?1049l"))
+	if pane.KittyKeys() {
+		t.Fatal("kitty keyboard mode leaked from the exited child into the shell")
+	}
+}
+
+func TestKittyKeyboardModesFollowProtocolSemantics(t *testing.T) {
+	pane := NewHolderPane(nil, 1, 40, 6)
+
+	pane.Feed([]byte("\x1b[=3u"))
+	pane.Feed([]byte("\x1b[=1;3u")) // clear flag 1, leave flag 2 set
+	if got := pane.keyboardMode[0].kittyFlags; got != 2 {
+		t.Fatalf("flags after selective clear = %d, want 2", got)
+	}
+	pane.Feed([]byte("\x1b[=1;2u")) // add flag 1
+	if got := pane.keyboardMode[0].kittyFlags; got != 3 {
+		t.Fatalf("flags after selective set = %d, want 3", got)
+	}
+	pane.Feed([]byte("\x1b[=4;1u")) // replace all flags
+	if got := pane.keyboardMode[0].kittyFlags; got != 4 {
+		t.Fatalf("flags after replacement = %d, want 4", got)
+	}
+}
+
+func TestKittyKeyboardViewsKeepIndependentModes(t *testing.T) {
+	pane := NewHolderPane(nil, 1, 40, 6)
+	pane.Feed([]byte("\x1b[>1u"))
+	pane.Feed([]byte("\x1b[?1049h"))
+	if pane.KittyKeys() {
+		t.Fatal("shell keyboard mode leaked into the full-screen view")
+	}
+	pane.Feed([]byte("\x1b[>2u"))
+	pane.Feed([]byte("\x1b[?1049l"))
+	if !pane.KittyKeys() || pane.keyboardMode[0].kittyFlags != 1 {
+		t.Fatal("returning to the shell did not restore its keyboard mode")
+	}
+}
+
+func TestModifyOtherKeysIsSharedAcrossViews(t *testing.T) {
+	pane := NewHolderPane(nil, 1, 40, 6)
+	pane.Feed([]byte("\x1b[>4;2m"))
+	pane.Feed([]byte("\x1b[?1049h"))
+	if !pane.KittyKeys() {
+		t.Fatal("modifyOtherKeys was lost on entry to the full-screen view")
+	}
+	pane.Feed([]byte("\x1b[?1049l"))
+	if !pane.KittyKeys() {
+		t.Fatal("modifyOtherKeys was lost on return to the shell view")
+	}
+	pane.Feed([]byte("\x1b[>4m"))
+	if pane.KittyKeys() {
+		t.Fatal("modifyOtherKeys remained enabled after its reset")
+	}
+}
+
+func TestTerminalResetClearsKeyboardModes(t *testing.T) {
+	pane := NewHolderPane(nil, 1, 40, 6)
+	pane.Feed([]byte("\x1b[>1u\x1b[?1049h\x1b[>2u\x1b[>4;2m\x1bc"))
+	if pane.KittyKeys() || pane.keyboardAlt || pane.modifyOtherKeys {
+		t.Fatal("terminal reset left keyboard mode enabled")
+	}
+	for index, mode := range pane.keyboardMode {
+		if mode.kittyFlags != 0 || len(mode.kittyStack) != 0 {
+			t.Fatalf("terminal reset left view %d state: %+v", index, mode)
+		}
+	}
+}
+
+func TestKittyKeyboardStackIsBounded(t *testing.T) {
+	pane := NewHolderPane(nil, 1, 40, 6)
+	for value := 1; value <= kittyKeyboardStackLimit+5; value++ {
+		pane.Feed([]byte(fmt.Sprintf("\x1b[>%du", value)))
+	}
+	if got := len(pane.keyboardMode[0].kittyStack); got != kittyKeyboardStackLimit {
+		t.Fatalf("keyboard stack size = %d, want %d", got, kittyKeyboardStackLimit)
+	}
+	pane.Feed([]byte("\x1b[<999u"))
+	if pane.KittyKeys() || len(pane.keyboardMode[0].kittyStack) != 0 {
+		t.Fatal("oversized pop did not empty and reset the keyboard stack")
+	}
+}
+
+func TestKeyboardProtocolScannerRecoversAcrossReads(t *testing.T) {
+	pane := NewHolderPane(nil, 1, 40, 6)
+	pane.Feed(nil) // empty output must be harmless
+
+	for _, part := range []byte("\x1b[>1u") {
+		pane.Feed([]byte{part})
+	}
+	if !pane.KittyKeys() {
+		t.Fatal("split kitty sequence was not detected")
+	}
+
+	pane.Feed([]byte("\x1bc"))
+	pane.Feed([]byte("\x1b[>1\x1b[>1u"))
+	if !pane.KittyKeys() {
+		t.Fatal("scanner did not recover from an interrupted CSI sequence")
+	}
+
+	pane.Feed([]byte("\x1bc"))
+	long := "\x1b[" + strings.Repeat("1;", 80)
+	pane.Feed([]byte(long))
+	pane.Feed([]byte("1m\x1b[>1u"))
+	if !pane.KittyKeys() {
+		t.Fatal("scanner lost the sequence after a long split CSI")
+	}
+}
+
 func TestBracketedPasteMode(t *testing.T) {
 	script := "printf '\\033[?2004h'; sleep 5"
 	if runtime.GOOS == "windows" {

--- a/internal/term/pane_test.go
+++ b/internal/term/pane_test.go
@@ -303,20 +303,32 @@ func TestKittyKeyboardViewsKeepIndependentModes(t *testing.T) {
 	}
 }
 
-func TestModifyOtherKeysIsSharedAcrossViews(t *testing.T) {
+func TestModifyOtherKeysMainModeIsInheritedByAltScreen(t *testing.T) {
 	pane := NewHolderPane(nil, 1, 40, 6)
 	pane.Feed([]byte("\x1b[>4;2m"))
 	pane.Feed([]byte("\x1b[?1049h"))
 	if !pane.KittyKeys() {
 		t.Fatal("modifyOtherKeys was lost on entry to the full-screen view")
 	}
-	pane.Feed([]byte("\x1b[?1049l"))
-	if !pane.KittyKeys() {
-		t.Fatal("modifyOtherKeys was lost on return to the shell view")
-	}
 	pane.Feed([]byte("\x1b[>4m"))
 	if pane.KittyKeys() {
-		t.Fatal("modifyOtherKeys remained enabled after its reset")
+		t.Fatal("alternate-screen modifyOtherKeys reset was not detected")
+	}
+	pane.Feed([]byte("\x1b[?1049l"))
+	if !pane.KittyKeys() {
+		t.Fatal("returning to the shell did not restore its modifyOtherKeys mode")
+	}
+}
+
+func TestModifyOtherKeysDoesNotLeakOutOfAltScreen(t *testing.T) {
+	pane := NewHolderPane(nil, 1, 40, 6)
+	pane.Feed([]byte("\x1b[?1049h\x1b[>4;2m"))
+	if !pane.KittyKeys() {
+		t.Fatal("alternate-screen modifyOtherKeys mode was not detected")
+	}
+	pane.Feed([]byte("\x1b[?1049l"))
+	if pane.KittyKeys() {
+		t.Fatal("modifyOtherKeys leaked from the exited child into the shell")
 	}
 }
 

--- a/internal/ui/keyboard_protocol_test.go
+++ b/internal/ui/keyboard_protocol_test.go
@@ -1,0 +1,56 @@
+package ui
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/patriceckhart/hrdx/internal/term"
+)
+
+// keyboardCaptureHost is the holder-side transport needed by NewHolderPane.
+// It records only pane input; the other operations are irrelevant here.
+type keyboardCaptureHost struct {
+	input []byte
+}
+
+func (h *keyboardCaptureHost) Write(_ int64, data []byte) {
+	h.input = append(h.input, data...)
+}
+
+func (*keyboardCaptureHost) Resize(int64, int, int)  {}
+func (*keyboardCaptureHost) Kill(int64)              {}
+func (*keyboardCaptureHost) Foreground(int64) string { return "" }
+
+func TestCSIUControlsReturnToLegacyEncodingAfterChildExitsAltScreen(t *testing.T) {
+	model := newTestModel("/tmp/api")
+	target := model.currentPane()
+	target.kind = "shell"
+	host := &keyboardCaptureHost{}
+	target.term = term.NewHolderPane(host, 1, 80, 24)
+	target.running = true
+
+	// While the full-screen child is active, its kitty request makes CSI-u the
+	// correct encoding to pass through.
+	target.term.Feed([]byte("\x1b[?1049h\x1b[>1u"))
+	childInput := []byte("\x1b[97;5u") // ctrl+a
+	model.updateRaw(childInput)
+	if !bytes.Equal(host.input, childInput) {
+		t.Fatalf("input while child active = %q, want CSI-u %q", host.input, childInput)
+	}
+
+	// The child returns to the shell without a kitty pop. The alternate screen
+	// switch still restores the shell's independent keyboard-protocol state, so
+	// common line-editing controls must be translated back to classic bytes.
+	host.input = nil
+	target.term.Feed([]byte("\x1b[?1049l"))
+	for _, input := range [][]byte{
+		[]byte("\x1b[97;5u"),  // ctrl+a
+		[]byte("\x1b[101;5u"), // ctrl+e
+		[]byte("\x1b[108;5u"), // ctrl+l
+	} {
+		model.updateRaw(input)
+	}
+	if want := []byte{0x01, 0x05, 0x0c}; !bytes.Equal(host.input, want) {
+		t.Fatalf("shell input after child exit = %q, want legacy controls %q", host.input, want)
+	}
+}

--- a/internal/ui/keyboard_protocol_test.go
+++ b/internal/ui/keyboard_protocol_test.go
@@ -29,18 +29,18 @@ func TestCSIUControlsReturnToLegacyEncodingAfterChildExitsAltScreen(t *testing.T
 	target.term = term.NewHolderPane(host, 1, 80, 24)
 	target.running = true
 
-	// While the full-screen child is active, its kitty request makes CSI-u the
-	// correct encoding to pass through.
-	target.term.Feed([]byte("\x1b[?1049h\x1b[>1u"))
+	// While the full-screen child is active, its kitty request and xterm
+	// fallback make CSI-u the correct encoding to pass through.
+	target.term.Feed([]byte("\x1b[?1049h\x1b[>1u\x1b[>4;2m"))
 	childInput := []byte("\x1b[97;5u") // ctrl+a
 	model.updateRaw(childInput)
 	if !bytes.Equal(host.input, childInput) {
 		t.Fatalf("input while child active = %q, want CSI-u %q", host.input, childInput)
 	}
 
-	// The child returns to the shell without a kitty pop. The alternate screen
-	// switch still restores the shell's independent keyboard-protocol state, so
-	// common line-editing controls must be translated back to classic bytes.
+	// The child returns to the shell without a kitty pop or xterm fallback
+	// reset. The alternate screen switch still restores the shell's keyboard
+	// state, so common line-editing controls return to classic bytes.
 	host.input = nil
 	target.term.Feed([]byte("\x1b[?1049l"))
 	for _, input := range [][]byte{


### PR DESCRIPTION
Some full-screen programs ask the terminal to send keys in an enhanced format while they are open. A terminal pane has one view for the normal shell and another for full-screen apps, and each view keeps its own keyboard setting.

hrdx tracked only one keyboard setting for the whole pane. After an app switched back to the shell without explicitly resetting that setting, hrdx could keep sending enhanced key sequences. The shell then printed pieces such as `97;5u` instead of handling Ctrl+A, Ctrl+E, or Ctrl+L. Closing and recreating the pane cleared the stuck setting, which is why the problem appeared only sometimes.

This change keeps the keyboard setting with the view it belongs to. Returning from a full-screen app now restores the shell view's normal keyboard input. It also reads complete terminal control sequences across PTY chunks and preserves the protocol's nested push/pop behavior.

Regression coverage checks both sides of the behavior: enhanced input still reaches the full-screen app, and Ctrl+A/Ctrl+E/Ctrl+L return to normal shell control bytes after the app closes.

Tested with:

- `go test -count=1 ./...`
- `go vet ./...`
- `go test -race ./internal/term ./internal/ui`
- manual reproduction with a full-screen switch that intentionally omits the keyboard reset