### PR TITLE
Add a Makefile install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: build test check run
+.PHONY: build install test check run
 
 build:
 	go build ./cmd/hrdx
+
+install:
+	go install ./cmd/hrdx
 
 test:
 	go test ./...


### PR DESCRIPTION
Adds `make install` alongside the existing build, test, check, and run targets.

The target uses `go install ./cmd/hrdx`, matching the local Go installation workflow used by Zot, and is included in `.PHONY`.

Verified with `make -n install`.