### PR TITLE
feat: support custom picker navigation keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Panes whose process exits (for example `exit` in a shell) close automatically; t
 
 ### Custom keys
 
-Prefix keys are remappable via a `keys.json` next to the state file (`~/Library/Application Support/hrdx/keys.json` on macOS, `$XDG_CONFIG_HOME/hrdx/keys.json` on Linux, `%AppData%\hrdx\keys.json` on Windows). It maps action names to a single key; an override replaces that action's default keys. The `prefix` action remaps the `ctrl+b` trigger itself, not just an action inside it:
+Prefix keys are remappable via a `keys.json` next to the state file (`~/Library/Application Support/hrdx/keys.json` on macOS, `$XDG_CONFIG_HOME/hrdx/keys.json` on Linux, `%AppData%\hrdx\keys.json` on Windows). It maps action names to a single key; an override replaces that action's default keys. The `prefix` action remaps the `ctrl+b` trigger itself, not just an action inside it. The picker also reads `picker-up` and `picker-down` for local menu navigation:
 
 ```json
 {
@@ -112,7 +112,7 @@ Prefix keys are remappable via a `keys.json` next to the state file (`~/Library/
 }
 ```
 
-Actions: `prefix`, `literal`, `quit`, `picker-right`, `picker-down`, `agent-right`, `agent-down`, `agent-cycle` (unbound by default), `shell-right`, `shell-down`, `workspace`, `tab-new`, `tab-next`, `tab-prev`, `space-next`, `space-prev`, `pane-next`, `pane-prev`, `find`, `close-pane`, `close-space`, `equalize`, `rename`, `menu`, `settings`, `scroll-up`, `scroll-down`, `live`.
+Actions: `prefix`, `literal`, `quit`, `picker-right`, `picker-down`, `picker-up`, `agent-right`, `agent-down`, `agent-cycle` (unbound by default), `shell-right`, `shell-down`, `workspace`, `tab-new`, `tab-next`, `tab-prev`, `space-next`, `space-prev`, `pane-next`, `pane-prev`, `find`, `close-pane`, `close-space`, `equalize`, `rename`, `menu`, `settings`, `scroll-up`, `scroll-down`, `live`.
 
 ## Mouse
 

--- a/README.md
+++ b/README.md
@@ -102,17 +102,19 @@ Panes whose process exits (for example `exit` in a shell) close automatically; t
 
 ### Custom keys
 
-Prefix keys are remappable via a `keys.json` next to the state file (`~/Library/Application Support/hrdx/keys.json` on macOS, `$XDG_CONFIG_HOME/hrdx/keys.json` on Linux, `%AppData%\hrdx\keys.json` on Windows). It maps action names to a single key; an override replaces that action's default keys. The `prefix` action remaps the `ctrl+b` trigger itself, not just an action inside it. The picker also reads `picker-up` and `picker-down` for local menu navigation:
+Keys are configurable via a `keys.json` next to the state file (`~/Library/Application Support/hrdx/keys.json` on macOS, `$XDG_CONFIG_HOME/hrdx/keys.json` on Linux, `%AppData%\hrdx\keys.json` on Windows). It maps action names to a single key. A prefix-action override replaces that action's default keys. The `prefix` action remaps the `ctrl+b` trigger itself, not just an action inside it. `navigate-up` and `navigate-down` add navigation keys for pickers, settings, and find while arrows and j/k remain available:
 
 ```json
 {
   "find": "f",
   "quit": "Q",
-  "agent-cycle": "g"
+  "agent-cycle": "g",
+  "navigate-up": "home",
+  "navigate-down": "end"
 }
 ```
 
-Actions: `prefix`, `literal`, `quit`, `picker-right`, `picker-down`, `picker-up`, `agent-right`, `agent-down`, `agent-cycle` (unbound by default), `shell-right`, `shell-down`, `workspace`, `tab-new`, `tab-next`, `tab-prev`, `space-next`, `space-prev`, `pane-next`, `pane-prev`, `find`, `close-pane`, `close-space`, `equalize`, `rename`, `menu`, `settings`, `scroll-up`, `scroll-down`, `live`.
+Actions: `prefix`, `literal`, `quit`, `picker-right`, `picker-down`, `agent-right`, `agent-down`, `agent-cycle` (unbound by default), `shell-right`, `shell-down`, `workspace`, `tab-new`, `tab-next`, `tab-prev`, `space-next`, `space-prev`, `pane-next`, `pane-prev`, `find`, `close-pane`, `close-space`, `equalize`, `rename`, `menu`, `settings`, `scroll-up`, `scroll-down`, `live`, `navigate-up`, `navigate-down`.
 
 ## Mouse
 

--- a/internal/ui/find.go
+++ b/internal/ui/find.go
@@ -91,16 +91,28 @@ func (m *Model) jumpTo(chosen findCandidate) {
 
 func (m Model) updateFindKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	candidates := m.findCandidates()
-	switch msg.String() {
-	case "esc":
-		m.closeFind()
-		return m, nil
-	case "up", "ctrl+p":
+	switch m.navigationAction(msg) {
+	case "navigate-up":
 		if len(candidates) > 0 {
 			m.findIndex = (m.findIndex - 1 + len(candidates)) % len(candidates)
 		}
 		return m, nil
-	case "down", "ctrl+n":
+	case "navigate-down":
+		if len(candidates) > 0 {
+			m.findIndex = (m.findIndex + 1) % len(candidates)
+		}
+		return m, nil
+	}
+	switch msg.String() {
+	case "esc":
+		m.closeFind()
+		return m, nil
+	case "ctrl+p":
+		if len(candidates) > 0 {
+			m.findIndex = (m.findIndex - 1 + len(candidates)) % len(candidates)
+		}
+		return m, nil
+	case "ctrl+n":
 		if len(candidates) > 0 {
 			m.findIndex = (m.findIndex + 1) % len(candidates)
 		}

--- a/internal/ui/find_test.go
+++ b/internal/ui/find_test.go
@@ -60,6 +60,27 @@ func TestFindFiltersAndJumps(t *testing.T) {
 	}
 }
 
+func TestFindCustomNavigationKeys(t *testing.T) {
+	model := newTestModel("/tmp/api", "/tmp/web")
+	model.navKeys = buildNavigationKeys(map[string]string{
+		"navigate-up": "home", "navigate-down": "end",
+	})
+	updated, _ := model.openFind()
+	model = updated.(Model)
+	model.findIndex = 1
+
+	updated, _ = model.updateKey(tea.KeyMsg{Type: tea.KeyHome})
+	model = updated.(Model)
+	if model.findIndex != 0 {
+		t.Fatalf("findIndex after home = %d, want 0", model.findIndex)
+	}
+	updated, _ = model.updateKey(tea.KeyMsg{Type: tea.KeyEnd})
+	model = updated.(Model)
+	if model.findIndex != 1 {
+		t.Fatalf("findIndex after end = %d, want 1", model.findIndex)
+	}
+}
+
 func TestFindEscCloses(t *testing.T) {
 	model := newTestModel("/tmp/api")
 	updated, _ := model.openFind()

--- a/internal/ui/keyboard_protocol_test.go
+++ b/internal/ui/keyboard_protocol_test.go
@@ -21,6 +21,58 @@ func (*keyboardCaptureHost) Resize(int64, int, int)  {}
 func (*keyboardCaptureHost) Kill(int64)              {}
 func (*keyboardCaptureHost) Foreground(int64) string { return "" }
 
+func TestEnhancedFunctionalKeysDriveLocalModes(t *testing.T) {
+	model := newTestModel("/tmp/api")
+	target := model.currentPane()
+	host := &keyboardCaptureHost{}
+	target.term = term.NewHolderPane(host, 1, 80, 24)
+	target.running = true
+	model.openKindPicker("tab", model.currentSpace(), "", rect{x: 1, y: 1})
+	model.menuIndex = 1
+
+	updated, _ := model.updateRaw([]byte("\x1b[1;1A"))
+	model = updated.(Model)
+	if model.menuIndex != 0 {
+		t.Fatalf("menuIndex after enhanced up = %d, want 0", model.menuIndex)
+	}
+	updated, _ = model.updateRaw([]byte("\x1b[1;1B"))
+	model = updated.(Model)
+	if model.menuIndex != 1 {
+		t.Fatalf("menuIndex after enhanced down = %d, want 1", model.menuIndex)
+	}
+	model.navKeys = buildNavigationKeys(map[string]string{"navigate-up": "home"})
+	updated, _ = model.updateRaw([]byte("\x1b[1;1H"))
+	model = updated.(Model)
+	if model.menuIndex != 0 {
+		t.Fatalf("menuIndex after enhanced custom home = %d, want 0", model.menuIndex)
+	}
+	model.updateRaw([]byte("\x1b[999~"))
+	if len(host.input) != 0 {
+		t.Fatalf("local mode leaked raw input to pane: %q", host.input)
+	}
+}
+
+func TestEnhancedFunctionalKeysFollowChildProtocolInTerminalMode(t *testing.T) {
+	model := newTestModel("/tmp/api")
+	target := model.currentPane()
+	host := &keyboardCaptureHost{}
+	target.term = term.NewHolderPane(host, 1, 80, 24)
+	target.running = true
+	input := []byte("\x1b[1;1A")
+
+	model.updateRaw(input)
+	if want := []byte("\x1b[A"); !bytes.Equal(host.input, want) {
+		t.Fatalf("legacy terminal input = %q, want %q", host.input, want)
+	}
+
+	host.input = nil
+	target.term.Feed([]byte("\x1b[>1u"))
+	model.updateRaw(input)
+	if !bytes.Equal(host.input, input) {
+		t.Fatalf("kitty terminal input = %q, want %q", host.input, input)
+	}
+}
+
 func TestCSIUControlsReturnToLegacyEncodingAfterChildExitsAltScreen(t *testing.T) {
 	model := newTestModel("/tmp/api")
 	target := model.currentPane()

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 )
 
-// keymapFile declares prefix key overrides in the state directory. The
-// format maps action names to a single key, replacing that action's
-// default keys: {"find": "f", "quit": "Q"}.
+// keymapFile declares key overrides in the state directory. The format maps
+// action names to a single key: {"find": "f", "navigate-up": "home"}.
 const keymapFile = "keys.json"
 
 // defaultPrefixKeys maps every prefix action to its default keys. The
@@ -20,7 +19,6 @@ var defaultPrefixKeys = map[string][]string{
 	"quit":         {"q"},
 	"picker-right": {"c"},
 	"picker-down":  {"C"},
-	"picker-up":    {},
 	"agent-right":  {"a"},
 	"agent-down":   {"A"},
 	"agent-cycle":  {},
@@ -46,6 +44,11 @@ var defaultPrefixKeys = map[string][]string{
 	"live":         {"esc", "G"},
 }
 
+var navigationActions = map[string]bool{
+	"navigate-up":   true,
+	"navigate-down": true,
+}
+
 // buildPrefixKeys resolves the key -> action table from the defaults and
 // the user's overrides. An override replaces all default keys of its
 // action and shadows whichever action held the key before. "prefix" is
@@ -56,7 +59,9 @@ func buildPrefixKeys(overrides map[string]string) map[string]string {
 	keys := map[string]string{}
 	overridden := map[string]bool{}
 	for action := range overrides {
-		overridden[action] = true
+		if _, ok := defaultPrefixKeys[action]; ok {
+			overridden[action] = true
+		}
 	}
 	for action, actionKeys := range defaultPrefixKeys {
 		if action == "prefix" || overridden[action] {
@@ -70,7 +75,9 @@ func buildPrefixKeys(overrides map[string]string) map[string]string {
 		if action == "prefix" {
 			continue
 		}
-		keys[key] = action
+		if _, ok := defaultPrefixKeys[action]; ok {
+			keys[key] = action
+		}
 	}
 	return keys
 }
@@ -88,7 +95,8 @@ func loadKeymap(dir string) (map[string]string, string) {
 	}
 	var unknown []string
 	for action, key := range overrides {
-		if _, ok := defaultPrefixKeys[action]; !ok {
+		_, prefixAction := defaultPrefixKeys[action]
+		if !prefixAction && !navigationActions[action] {
 			unknown = append(unknown, action)
 			delete(overrides, action)
 			continue
@@ -103,15 +111,15 @@ func loadKeymap(dir string) (map[string]string, string) {
 	return overrides, ""
 }
 
-// buildPickerKeys resolves custom picker navigation keys from keys.json.
-// Defaults stay hard-coded so arrows and j/k keep working.
-func buildPickerKeys(overrides map[string]string) map[string]string {
+// buildNavigationKeys resolves extra local navigation keys from keys.json.
+// Arrows and j/k remain available when custom keys are configured.
+func buildNavigationKeys(overrides map[string]string) map[string]string {
 	keys := map[string]string{}
-	for action, key := range overrides {
-		switch action {
-		case "picker-up", "picker-down":
-			keys[key] = action
-		}
+	if key := overrides["navigate-up"]; key != "" {
+		keys[key] = "navigate-up"
+	}
+	if key := overrides["navigate-down"]; key != "" {
+		keys[key] = "navigate-down"
 	}
 	return keys
 }

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -20,6 +20,7 @@ var defaultPrefixKeys = map[string][]string{
 	"quit":         {"q"},
 	"picker-right": {"c"},
 	"picker-down":  {"C"},
+	"picker-up":    {},
 	"agent-right":  {"a"},
 	"agent-down":   {"A"},
 	"agent-cycle":  {},
@@ -100,4 +101,17 @@ func loadKeymap(dir string) (map[string]string, string) {
 		return overrides, keymapFile + ": unknown actions: " + strings.Join(unknown, ", ")
 	}
 	return overrides, ""
+}
+
+// buildPickerKeys resolves custom picker navigation keys from keys.json.
+// Defaults stay hard-coded so arrows and j/k keep working.
+func buildPickerKeys(overrides map[string]string) map[string]string {
+	keys := map[string]string{}
+	for action, key := range overrides {
+		switch action {
+		case "picker-up", "picker-down":
+			keys[key] = action
+		}
+	}
+	return keys
 }

--- a/internal/ui/keymap_test.go
+++ b/internal/ui/keymap_test.go
@@ -30,6 +30,13 @@ func TestBuildPrefixKeysOverride(t *testing.T) {
 	}
 }
 
+func TestBuildPrefixKeysExcludesNavigationOverrides(t *testing.T) {
+	keys := buildPrefixKeys(map[string]string{"navigate-up": "u", "navigate-down": "d"})
+	if keys["u"] != "scroll-up" || keys["d"] != "scroll-down" {
+		t.Fatalf("navigation overrides changed prefix keys: %v", keys)
+	}
+}
+
 func TestBuildPrefixKeysExcludesPrefixTrigger(t *testing.T) {
 	keys := buildPrefixKeys(nil)
 	if keys["ctrl+b"] != "literal" {
@@ -91,15 +98,15 @@ func TestIsSpuriousModifierKey(t *testing.T) {
 func TestLoadKeymap(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, keymapFile),
-		[]byte(`{"find": "f", "picker-up": "home", "bogus": "x"}`), 0o644); err != nil {
+		[]byte(`{"find": "f", "navigate-up": "home", "bogus": "x"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	overrides, problem := loadKeymap(dir)
 	if overrides["find"] != "f" {
 		t.Fatalf("overrides = %v, want find -> f", overrides)
 	}
-	if overrides["picker-up"] != "home" {
-		t.Fatalf("overrides = %v, want picker-up -> home", overrides)
+	if overrides["navigate-up"] != "home" {
+		t.Fatalf("overrides = %v, want navigate-up -> home", overrides)
 	}
 	if _, ok := overrides["bogus"]; ok {
 		t.Fatal("unknown action must be dropped")
@@ -109,13 +116,13 @@ func TestLoadKeymap(t *testing.T) {
 	}
 }
 
-func TestBuildPickerKeys(t *testing.T) {
-	keys := buildPickerKeys(map[string]string{"picker-up": "home", "picker-down": "end", "find": "f"})
-	if keys["home"] != "picker-up" || keys["end"] != "picker-down" {
-		t.Fatalf("picker keys = %v, want home/end bindings", keys)
+func TestBuildNavigationKeys(t *testing.T) {
+	keys := buildNavigationKeys(map[string]string{"navigate-up": "home", "navigate-down": "end", "find": "f"})
+	if keys["home"] != "navigate-up" || keys["end"] != "navigate-down" {
+		t.Fatalf("navigation keys = %v, want home/end bindings", keys)
 	}
 	if _, ok := keys["f"]; ok {
-		t.Fatal("non-picker keys must not be included")
+		t.Fatal("non-navigation keys must not be included")
 	}
 }
 
@@ -147,7 +154,7 @@ func TestPrefixHintEntriesUseSpaceSeparator(t *testing.T) {
 	}
 }
 
-func TestMenuPickerKeysDispatch(t *testing.T) {
+func TestMenuNavigationKeysDispatch(t *testing.T) {
 	model := newTestModel("/tmp/api")
 	model.openKindPicker("tab", model.currentSpace(), "", rect{x: 1, y: 1})
 	model.menuIndex = 1
@@ -164,8 +171,8 @@ func TestMenuPickerKeysDispatch(t *testing.T) {
 		t.Fatalf("menuIndex after j = %d, want 1", model.menuIndex)
 	}
 
-	model.keyOverrides = map[string]string{"picker-up": "home", "picker-down": "end"}
-	model.pickerKeys = buildPickerKeys(model.keyOverrides)
+	model.keyOverrides = map[string]string{"navigate-up": "home", "navigate-down": "end"}
+	model.navKeys = buildNavigationKeys(model.keyOverrides)
 
 	updated, _ = model.updateKey(tea.KeyMsg{Type: tea.KeyHome})
 	model = updated.(Model)

--- a/internal/ui/keymap_test.go
+++ b/internal/ui/keymap_test.go
@@ -91,18 +91,31 @@ func TestIsSpuriousModifierKey(t *testing.T) {
 func TestLoadKeymap(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, keymapFile),
-		[]byte(`{"find": "f", "bogus": "x"}`), 0o644); err != nil {
+		[]byte(`{"find": "f", "picker-up": "home", "bogus": "x"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	overrides, problem := loadKeymap(dir)
 	if overrides["find"] != "f" {
 		t.Fatalf("overrides = %v, want find -> f", overrides)
 	}
+	if overrides["picker-up"] != "home" {
+		t.Fatalf("overrides = %v, want picker-up -> home", overrides)
+	}
 	if _, ok := overrides["bogus"]; ok {
 		t.Fatal("unknown action must be dropped")
 	}
 	if problem == "" {
 		t.Fatal("unknown action should surface a problem message")
+	}
+}
+
+func TestBuildPickerKeys(t *testing.T) {
+	keys := buildPickerKeys(map[string]string{"picker-up": "home", "picker-down": "end", "find": "f"})
+	if keys["home"] != "picker-up" || keys["end"] != "picker-down" {
+		t.Fatalf("picker keys = %v, want home/end bindings", keys)
+	}
+	if _, ok := keys["f"]; ok {
+		t.Fatal("non-picker keys must not be included")
 	}
 }
 
@@ -131,5 +144,38 @@ func TestPrefixHintEntriesUseSpaceSeparator(t *testing.T) {
 				t.Fatalf("hint keys %q contain a slash separator", entry[0])
 			}
 		}
+	}
+}
+
+func TestMenuPickerKeysDispatch(t *testing.T) {
+	model := newTestModel("/tmp/api")
+	model.openKindPicker("tab", model.currentSpace(), "", rect{x: 1, y: 1})
+	model.menuIndex = 1
+
+	updated, _ := model.updateKey(tea.KeyMsg{Type: tea.KeyUp})
+	model = updated.(Model)
+	if model.menuIndex != 0 {
+		t.Fatalf("menuIndex after up = %d, want 0", model.menuIndex)
+	}
+
+	updated, _ = model.updateKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	model = updated.(Model)
+	if model.menuIndex != 1 {
+		t.Fatalf("menuIndex after j = %d, want 1", model.menuIndex)
+	}
+
+	model.keyOverrides = map[string]string{"picker-up": "home", "picker-down": "end"}
+	model.pickerKeys = buildPickerKeys(model.keyOverrides)
+
+	updated, _ = model.updateKey(tea.KeyMsg{Type: tea.KeyHome})
+	model = updated.(Model)
+	if model.menuIndex != 0 {
+		t.Fatalf("menuIndex after home = %d, want 0", model.menuIndex)
+	}
+
+	updated, _ = model.updateKey(tea.KeyMsg{Type: tea.KeyEnd})
+	model = updated.(Model)
+	if model.menuIndex != 1 {
+		t.Fatalf("menuIndex after end = %d, want 1", model.menuIndex)
 	}
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -148,7 +148,7 @@ type Model struct {
 	menuIndex     int
 	customMenus   []api.MenuRegister // ephemeral socket API context-menu entries
 	pickItems     []menuItem         // kind picker entries while it is open
-	pickerKeys    map[string]string  // custom picker navigation overrides from keys.json
+	navKeys       map[string]string  // custom local navigation overrides from keys.json
 	pickAction    string             // "space", "tab", "split-right", "split-down", "settings"
 	pickSpace     *space             // tab target for the picker
 	pickPath      string             // directory for a pending new workspace
@@ -432,7 +432,7 @@ func New(config Config, paths []string, statePath string, saved state.State) Mod
 		wasBusy: map[int]bool{}, soundSeq: map[int]uint64{}, paneAttention: map[int]bool{},
 		soundOn: saved.Sound, status: harnessProblem,
 		soundKind: saved.SoundKind, notifyOn: saved.Notify, themeName: saved.Theme,
-		prefixKeys: buildPrefixKeys(keymapOverrides), pickerKeys: buildPickerKeys(keymapOverrides), keyOverrides: keymapOverrides}
+		prefixKeys: buildPrefixKeys(keymapOverrides), navKeys: buildNavigationKeys(keymapOverrides), keyOverrides: keymapOverrides}
 	model.prefixTrigger = model.primaryKey("prefix")
 	if statePath != "" {
 		for _, problem := range []string{
@@ -941,10 +941,14 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// updateRaw routes raw CSI-u input from the host terminal. Kitty-aware
-// children (zot) get the sequence verbatim so chords like ctrl+1 survive;
-// legacy children (shells) get the classic encoding instead.
+// updateRaw routes enhanced keyboard input from the host terminal. Local
+// modes receive Bubble Tea key messages. Kitty-aware children get the raw
+// sequence, while legacy children get the classic encoding when available.
 func (m Model) updateRaw(raw []byte) (tea.Model, tea.Cmd) {
+	functionalKey, enhancedFunctional := parseEnhancedFunctionalKey(raw)
+	if enhancedFunctional && m.mode != modeTerminal {
+		return m.updateKey(functionalKey)
+	}
 	// Shift+PgUp / Shift+PgDn scroll the focused pane's history.
 	if m.mode == modeTerminal {
 		switch string(raw) {
@@ -970,8 +974,17 @@ func (m Model) updateRaw(raw []byte) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	}
+	// Local modes own keyboard input. Unknown host sequences must not leak
+	// through an open menu, prompt, settings window, or finder to the PTY.
+	if m.mode != modeTerminal {
+		return m, nil
+	}
 	current := m.currentPane()
 	if current == nil || current.term == nil || !current.running {
+		return m, nil
+	}
+	if enhancedFunctional && !current.term.KittyKeys() {
+		current.term.Write(term.EncodeKey(functionalKey, current.term.AppCursor()))
 		return m, nil
 	}
 	if !ok || current.term.KittyKeys() {
@@ -1049,23 +1062,17 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case modeMenu:
 		items := m.menuItems()
-		switch m.pickerKeys[msg.String()] {
-		case "picker-up":
+		switch m.navigationAction(msg) {
+		case "navigate-up":
 			m.menuIndex = (m.menuIndex - 1 + len(items)) % len(items)
 			return m, nil
-		case "picker-down":
+		case "navigate-down":
 			m.menuIndex = (m.menuIndex + 1) % len(items)
 			return m, nil
 		}
 		switch msg.String() {
 		case "esc", "q":
 			m.closeMenu()
-			return m, nil
-		case "up", "k":
-			m.menuIndex = (m.menuIndex - 1 + len(items)) % len(items)
-			return m, nil
-		case "down", "j":
-			m.menuIndex = (m.menuIndex + 1) % len(items)
 			return m, nil
 		case "enter":
 			return m.runMenuAction(items[m.menuIndex].action)
@@ -1166,6 +1173,17 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // unaffected.
 func isSpuriousModifierKey(msg tea.KeyMsg) bool {
 	return msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && msg.Runes[0] == 0
+}
+
+func (m Model) navigationAction(msg tea.KeyMsg) string {
+	switch msg.String() {
+	case "up", "k":
+		return "navigate-up"
+	case "down", "j":
+		return "navigate-down"
+	default:
+		return m.navKeys[msg.String()]
+	}
 }
 
 func (m Model) runPrefix(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -2685,15 +2703,15 @@ func (m Model) renderFooter() string {
 	case modeMenu:
 		badge = styleBadgePrefix.Render(" MENU ")
 		body = styleBarMuted.Render(" click or arrows + enter, esc closes")
-		if hint := m.menuNavigationHint(); hint != "" {
-			body += styleBarText.Render("  " + hint)
-		}
+		body += m.navigationHint()
 	case modeSettings:
 		badge = styleBadgeInput.Render(" SETTINGS ")
 		body = styleBarMuted.Render(" enter toggles, tab switches section, esc closes")
+		body += m.navigationHint()
 	case modeFind:
 		badge = styleBadgeInput.Render(" FIND ")
 		body = styleBarMuted.Render(" type to filter, arrows select, enter jumps, esc closes")
+		body += m.navigationHint()
 	case modePrefix:
 		badge = styleBadgePrefix.Render(" " + strings.ToUpper(m.prefixTrigger) + " ")
 		body = m.prefixHints(m.width - lipgloss.Width(badge) - lipgloss.Width(right))
@@ -2741,15 +2759,18 @@ func (m Model) renderFooter() string {
 	return badge + body + styleBar.Render(strings.Repeat(" ", max(0, gap))) + right
 }
 
-func (m Model) menuNavigationHint() string {
+func (m Model) navigationHint() string {
 	var custom []string
-	if key := strings.TrimSpace(m.keyOverrides["picker-up"]); key != "" {
+	if key := strings.TrimSpace(m.keyOverrides["navigate-up"]); key != "" {
 		custom = append(custom, key)
 	}
-	if key := strings.TrimSpace(m.keyOverrides["picker-down"]); key != "" {
+	if key := strings.TrimSpace(m.keyOverrides["navigate-down"]); key != "" {
 		custom = append(custom, key)
 	}
-	return strings.Join(custom, "/")
+	if len(custom) == 0 {
+		return ""
+	}
+	return styleBarText.Render("  " + strings.Join(custom, "/"))
 }
 
 func (m Model) agentSummary() string {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -148,6 +148,7 @@ type Model struct {
 	menuIndex     int
 	customMenus   []api.MenuRegister // ephemeral socket API context-menu entries
 	pickItems     []menuItem         // kind picker entries while it is open
+	pickerKeys    map[string]string  // custom picker navigation overrides from keys.json
 	pickAction    string             // "space", "tab", "split-right", "split-down", "settings"
 	pickSpace     *space             // tab target for the picker
 	pickPath      string             // directory for a pending new workspace
@@ -431,7 +432,7 @@ func New(config Config, paths []string, statePath string, saved state.State) Mod
 		wasBusy: map[int]bool{}, soundSeq: map[int]uint64{}, paneAttention: map[int]bool{},
 		soundOn: saved.Sound, status: harnessProblem,
 		soundKind: saved.SoundKind, notifyOn: saved.Notify, themeName: saved.Theme,
-		prefixKeys: buildPrefixKeys(keymapOverrides), keyOverrides: keymapOverrides}
+		prefixKeys: buildPrefixKeys(keymapOverrides), pickerKeys: buildPickerKeys(keymapOverrides), keyOverrides: keymapOverrides}
 	model.prefixTrigger = model.primaryKey("prefix")
 	if statePath != "" {
 		for _, problem := range []string{
@@ -1048,6 +1049,14 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case modeMenu:
 		items := m.menuItems()
+		switch m.pickerKeys[msg.String()] {
+		case "picker-up":
+			m.menuIndex = (m.menuIndex - 1 + len(items)) % len(items)
+			return m, nil
+		case "picker-down":
+			m.menuIndex = (m.menuIndex + 1) % len(items)
+			return m, nil
+		}
 		switch msg.String() {
 		case "esc", "q":
 			m.closeMenu()
@@ -2676,6 +2685,9 @@ func (m Model) renderFooter() string {
 	case modeMenu:
 		badge = styleBadgePrefix.Render(" MENU ")
 		body = styleBarMuted.Render(" click or arrows + enter, esc closes")
+		if hint := m.menuNavigationHint(); hint != "" {
+			body += styleBarText.Render("  " + hint)
+		}
 	case modeSettings:
 		badge = styleBadgeInput.Render(" SETTINGS ")
 		body = styleBarMuted.Render(" enter toggles, tab switches section, esc closes")
@@ -2727,6 +2739,17 @@ func (m Model) renderFooter() string {
 	}
 	gap := m.width - badgeWidth - lipgloss.Width(body) - lipgloss.Width(right)
 	return badge + body + styleBar.Render(strings.Repeat(" ", max(0, gap))) + right
+}
+
+func (m Model) menuNavigationHint() string {
+	var custom []string
+	if key := strings.TrimSpace(m.keyOverrides["picker-up"]); key != "" {
+		custom = append(custom, key)
+	}
+	if key := strings.TrimSpace(m.keyOverrides["picker-down"]); key != "" {
+		custom = append(custom, key)
+	}
+	return strings.Join(custom, "/")
 }
 
 func (m Model) agentSummary() string {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -261,6 +261,21 @@ func TestFooterShowsAgentSummaryOnRight(t *testing.T) {
 	}
 }
 
+func TestMenuFooterShowsCustomPickerKeys(t *testing.T) {
+	model := newTestModel("/tmp/api")
+	model.keyOverrides = map[string]string{"picker-up": "home", "picker-down": "end"}
+	model.pickerKeys = buildPickerKeys(model.keyOverrides)
+	model.openKindPicker("tab", model.currentSpace(), "", rect{x: 1, y: 1})
+
+	footer := model.renderFooter()
+	if !strings.Contains(footer, "click or arrows + enter, esc closes") {
+		t.Fatalf("menu footer lost default hint: %q", footer)
+	}
+	if !strings.Contains(footer, "home/end") {
+		t.Fatalf("menu footer = %q, want custom picker keys", footer)
+	}
+}
+
 func TestFooterInputDoesNotWrapOnNarrowWindow(t *testing.T) {
 	model := newTestModel("/tmp/api")
 	model.width = 45

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -261,10 +261,10 @@ func TestFooterShowsAgentSummaryOnRight(t *testing.T) {
 	}
 }
 
-func TestMenuFooterShowsCustomPickerKeys(t *testing.T) {
+func TestMenuFooterShowsCustomNavigationKeys(t *testing.T) {
 	model := newTestModel("/tmp/api")
-	model.keyOverrides = map[string]string{"picker-up": "home", "picker-down": "end"}
-	model.pickerKeys = buildPickerKeys(model.keyOverrides)
+	model.keyOverrides = map[string]string{"navigate-up": "home", "navigate-down": "end"}
+	model.navKeys = buildNavigationKeys(model.keyOverrides)
 	model.openKindPicker("tab", model.currentSpace(), "", rect{x: 1, y: 1})
 
 	footer := model.renderFooter()

--- a/internal/ui/rawinput.go
+++ b/internal/ui/rawinput.go
@@ -9,9 +9,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// Bubble Tea v1 reports kitty-keyboard CSI-u sequences (needed for chords
-// like ctrl+1) as unexported "unknown" messages. rawInputBytes recovers the
-// raw bytes from those messages via reflection.
+// Bubble Tea v1 reports some kitty-keyboard sequences as unexported
+// "unknown" messages. rawInputBytes recovers their bytes via reflection.
 func rawInputBytes(message tea.Msg) ([]byte, bool) {
 	switch fmt.Sprintf("%T", message) {
 	case "tea.unknownCSISequenceMsg":
@@ -34,6 +33,37 @@ const (
 	modAlt   = 2
 	modCtrl  = 4
 )
+
+// parseEnhancedFunctionalKey decodes unmodified functional keys emitted
+// with an explicit modifier parameter by the kitty keyboard protocol.
+func parseEnhancedFunctionalKey(data []byte) (tea.KeyMsg, bool) {
+	var keyType tea.KeyType
+	switch string(data) {
+	case "\x1b[1;1A":
+		keyType = tea.KeyUp
+	case "\x1b[1;1B":
+		keyType = tea.KeyDown
+	case "\x1b[1;1C":
+		keyType = tea.KeyRight
+	case "\x1b[1;1D":
+		keyType = tea.KeyLeft
+	case "\x1b[1;1H":
+		keyType = tea.KeyHome
+	case "\x1b[1;1F":
+		keyType = tea.KeyEnd
+	case "\x1b[2;1~":
+		keyType = tea.KeyInsert
+	case "\x1b[3;1~":
+		keyType = tea.KeyDelete
+	case "\x1b[5;1~":
+		keyType = tea.KeyPgUp
+	case "\x1b[6;1~":
+		keyType = tea.KeyPgDown
+	default:
+		return tea.KeyMsg{}, false
+	}
+	return tea.KeyMsg{Type: keyType}, true
+}
 
 // parseCSIU decodes a kitty keyboard sequence ESC [ code ; mods u.
 // It returns the base codepoint and the modifier bitmask.

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -184,6 +184,14 @@ func (m Model) settingsTabCells() []tabCell {
 
 func (m Model) updateSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	rows := m.settingsRows()
+	switch m.navigationAction(msg) {
+	case "navigate-up":
+		m.settingsIndex = (m.settingsIndex - 1 + len(rows)) % len(rows)
+		return m, nil
+	case "navigate-down":
+		m.settingsIndex = (m.settingsIndex + 1) % len(rows)
+		return m, nil
+	}
 	switch msg.String() {
 	case "esc", "q", "ctrl+c":
 		m.closeSettings()
@@ -195,12 +203,6 @@ func (m Model) updateSettingsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "shift+tab", "left", "h":
 		m.settingsTab = (m.settingsTab - 1 + len(settingsTabNames)) % len(settingsTabNames)
 		m.settingsIndex = 0
-		return m, nil
-	case "up", "k":
-		m.settingsIndex = (m.settingsIndex - 1 + len(rows)) % len(rows)
-		return m, nil
-	case "down", "j":
-		m.settingsIndex = (m.settingsIndex + 1) % len(rows)
 		return m, nil
 	case "enter", " ":
 		if m.settingsIndex >= 0 && m.settingsIndex < len(rows) {

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -69,6 +69,26 @@ func TestThemeSettingsScrollAndSelectBundledPreset(t *testing.T) {
 	}
 }
 
+func TestSettingsCustomNavigationKeys(t *testing.T) {
+	model := newTestModel("/tmp/api")
+	model.navKeys = buildNavigationKeys(map[string]string{
+		"navigate-up": "home", "navigate-down": "end",
+	})
+	model.openSettings()
+	model.settingsIndex = 1
+
+	updated, _ := model.updateKey(tea.KeyMsg{Type: tea.KeyHome})
+	model = updated.(Model)
+	if model.settingsIndex != 0 {
+		t.Fatalf("settingsIndex after home = %d, want 0", model.settingsIndex)
+	}
+	updated, _ = model.updateKey(tea.KeyMsg{Type: tea.KeyEnd})
+	model = updated.(Model)
+	if model.settingsIndex != 1 {
+		t.Fatalf("settingsIndex after end = %d, want 1", model.settingsIndex)
+	}
+}
+
 func TestSettingsMouseOutsideCloses(t *testing.T) {
 	model := newTestModel("/tmp/api")
 	model.openSettings()


### PR DESCRIPTION
Fixes #14.

Adds keys.json support for picker-up and picker-down so the harness/CLI picker can use custom navigation keys while keeping arrows and j/k as defaults.

Checks:
- go test ./internal/ui -run 'TestLoadKeymap|TestBuildPickerKeys|TestMenuPickerKeysDispatch|TestMenuFooterShowsCustomPickerKeys'
- go test ./internal/ui
- go test ./...
- go vet ./...
- git diff --check