### PR TITLE
fix(ui): close sidebar tabs independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Actions: `prefix`, `literal`, `quit`, `picker-right`, `picker-down`, `agent-righ
 
 Everything is clickable: workspace, tab, and pane rows in the sidebar, the collapse arrow beside `WORKSPACES`, the main tab bar, menus, and the settings entry at the bottom. The compact sidebar shortens workspace and branch names after six display cells and pane names after two, hides the `WORKSPACES` heading and new-workspace entry, and shows only the left-aligned expand arrow and settings gear. Drag workspaces to reorder them, drag pane borders to resize, right-click for context menus, and drag with the left button to select text. Completed selections are copied straight to your clipboard by default; turn this off under the terminal tab in settings when you only want the highlight. Wheel events go to the pane under the cursor: agent TUIs scroll themselves, shells scroll their local history, and `shift+pgup` / `shift+pgdn` do the same from the keyboard.
 
+Sidebar context menus follow the clicked row: workspace names and Git branch rows offer workspace actions; the first pane row of each tab in a multi-tab workspace offers tab actions; other pane rows offer pane actions. Closing a tab leaves the workspace and its other tabs intact. The final tab cannot be closed through the tab menu, and pane menus omit Close for a tab's last pane. To close the entire workspace, use its workspace menu or the workspace-close key binding. Blank rows and dividers do not change focus. Custom socket menu entries follow the same scopes (`sidebar`, `tab`, or `pane`).
+
 ## Remote and container panes
 
 Every pane is a real PTY, so a shell pane can connect to a remote host, Docker container, or Kubernetes workload. For an interactive shell:

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1917,11 +1917,17 @@ func (m Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	// context menu next to the cursor.
 	if msg.Button == tea.MouseButtonRight && msg.Action == tea.MouseActionPress {
 		hit := m.sidebarHit(msg.Y - 1)
-		descendant := hit.kind == "space" || hit.kind == "tab" || hit.kind == "pane"
-		if descendant && hit.space >= 0 && hit.space < len(m.spaces) {
+		if hit.space >= 0 && hit.space < len(m.spaces) {
 			m.selected = hit.space
 			m.clearFocusedAttention()
-			m.openSpaceMenu(m.spaces[hit.space], rect{x: msg.X, y: msg.Y - 1})
+			if hit.tabRow && hit.tab >= 0 && hit.tab < len(m.spaces[hit.space].tabs) {
+				target := m.spaces[hit.space]
+				target.active = hit.tab
+				m.resizePanes(target)
+				m.openTabMenu(target.tabs[hit.tab], rect{x: msg.X, y: msg.Y - 1})
+			} else if hit.kind == "space" || hit.kind == "tab" || hit.kind == "pane" {
+				m.openSpaceMenu(m.spaces[hit.space], rect{x: msg.X, y: msg.Y - 1})
+			}
 		}
 		return m, nil
 	}
@@ -2039,11 +2045,12 @@ func (m *Model) focusPane(owner *space, target *pane) {
 // "tab", "pane", or "new". The render and mouse hit test share this layout
 // so they can never drift apart.
 type sidebarRow struct {
-	label string
-	kind  string
-	space int
-	tab   int
-	pane  int
+	label  string
+	kind   string
+	space  int
+	tab    int
+	pane   int
+	tabRow bool
 }
 
 // paneBusy reports whether a pane running an agent (agent panes, or shell
@@ -2306,6 +2313,7 @@ func (m Model) sidebarRows() []sidebarRow {
 				rows = append(rows, sidebarRow{
 					label: rowIndent + m.sidebarPaneIcon(currentPane) + nameLabel + state + trailing,
 					kind:  "pane", space: spaceIndex, tab: tabIndex, pane: paneIndex,
+					tabRow: showTabs && shownPanes == 0,
 				})
 				shownPanes++
 			}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1913,20 +1913,36 @@ func (m Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Right-click anywhere in a workspace hierarchy opens the workspace
-	// context menu next to the cursor.
+	// Context menus follow the row's scope. Only workspace rows may
+	// offer workspace close; combined tab/pane rows offer tab actions.
 	if msg.Button == tea.MouseButtonRight && msg.Action == tea.MouseActionPress {
 		hit := m.sidebarHit(msg.Y - 1)
-		if hit.space >= 0 && hit.space < len(m.spaces) {
+		if hit.space < 0 || hit.space >= len(m.spaces) {
+			return m, nil
+		}
+		target := m.spaces[hit.space]
+		at := rect{x: msg.X, y: msg.Y - 1}
+		switch hit.kind {
+		case "space":
 			m.selected = hit.space
 			m.clearFocusedAttention()
-			if hit.tabRow && hit.tab >= 0 && hit.tab < len(m.spaces[hit.space].tabs) {
-				target := m.spaces[hit.space]
-				target.active = hit.tab
-				m.resizePanes(target)
-				m.openTabMenu(target.tabs[hit.tab], rect{x: msg.X, y: msg.Y - 1})
-			} else if hit.kind == "space" || hit.kind == "tab" || hit.kind == "pane" {
-				m.openSpaceMenu(m.spaces[hit.space], rect{x: msg.X, y: msg.Y - 1})
+			m.openSpaceMenu(target, at)
+		case "pane":
+			if hit.tab < 0 || hit.tab >= len(target.tabs) {
+				return m, nil
+			}
+			currentTab := target.tabs[hit.tab]
+			if hit.pane < 0 || hit.pane >= len(currentTab.panes) {
+				return m, nil
+			}
+			m.selected = hit.space
+			m.focusPane(target, currentTab.panes[hit.pane])
+			m.resizePanes(target)
+			m.persist()
+			if hit.tabRow {
+				m.openTabMenu(currentTab, at)
+			} else {
+				m.openMenu(currentTab.panes[hit.pane], at)
 			}
 		}
 		return m, nil

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -425,6 +425,48 @@ func TestMouseSelectsSidebarTabAndPane(t *testing.T) {
 	}
 }
 
+func TestSidebarTabContextMenuClosesOnlyTab(t *testing.T) {
+	model := newTestModel("/tmp/api")
+	currentSpace := model.spaces[0]
+	model.addTab(currentSpace, "shell")
+	secondTab := currentSpace.tabs[1]
+
+	// The first pane row for a multi-tab workspace is also its tab row.
+	// Screen Y is sidebar row + 1: row 4 is the first tab row.
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 7, Y: 5, Button: tea.MouseButtonRight, Action: tea.MouseActionPress})
+	got := updated.(Model)
+	if got.mode != modeMenu || got.menuTab != currentSpace.tabs[0] || got.menuSpace != nil {
+		t.Fatalf("sidebar tab context target = tab %p/space %p, want tab %p and no space menu",
+			got.menuTab, got.menuSpace, currentSpace.tabs[0])
+	}
+
+	updated, _ = got.runMenuAction("tab-close")
+	got = updated.(Model)
+	if len(got.spaces) != 1 {
+		t.Fatalf("workspaces after closing tab = %d, want 1", len(got.spaces))
+	}
+	if len(got.spaces[0].tabs) != 1 || got.spaces[0].tabs[0] != secondTab {
+		t.Fatalf("tabs after closing tab = %v, want the second tab only", got.spaces[0].tabs)
+	}
+}
+
+func TestSidebarWorkspaceContextMenuStillClosesWorkspace(t *testing.T) {
+	model := newTestModel("/tmp/api", "/tmp/web")
+
+	// The first workspace row is screen Y=4.
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 4, Button: tea.MouseButtonRight, Action: tea.MouseActionPress})
+	got := updated.(Model)
+	if got.mode != modeMenu || got.menuSpace != got.spaces[0] || got.menuTab != nil {
+		t.Fatalf("workspace context target = space %p/tab %p, want space menu", got.menuSpace, got.menuTab)
+	}
+
+	updated, _ = got.runMenuAction("space-close")
+	got = updated.(Model)
+	if len(got.spaces) != 1 || got.spaces[0].name != "web" {
+		t.Fatalf("workspaces after closing workspace = %v, want web only", got.spaces)
+	}
+}
+
 func TestMouseSidebarPaneClickPersists(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state.json")
 	model := New(Config{Shell: "/bin/sh"}, []string{"/tmp/api"}, statePath, state.State{})

--- a/internal/ui/sidebar_context_test.go
+++ b/internal/ui/sidebar_context_test.go
@@ -1,0 +1,139 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/patriceckhart/hrdx/internal/state"
+)
+
+func TestSidebarContextTargets(t *testing.T) {
+	for _, collapsed := range []bool{false, true} {
+		for _, multipleTabs := range []bool{false, true} {
+			model := newTestModel(t.TempDir(), t.TempDir())
+			model.sideCollapsed = collapsed
+			owner := model.spaces[1]
+			if multipleTabs {
+				model.addTab(owner, "shell")
+			}
+			targetTab := owner.tabs[0]
+			extra := &pane{id: model.nextID, kind: "shell"}
+			model.nextID++
+			targetTab.panes = append(targetTab.panes, extra)
+			targetTab.layout = fallbackLayout(targetTab.panes)
+			for rowIndex, row := range model.sidebarRows() {
+				if row.kind != "pane" || row.space != 1 || row.tab != 0 {
+					continue
+				}
+				model.selected = 0
+				owner.active = len(owner.tabs) - 1
+				previous := model.spaces[0].tab().panes[0]
+				target := targetTab.panes[row.pane]
+				model.paneAttention[previous.id] = true
+				model.paneAttention[target.id] = true
+				updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: rowIndex + 1, Button: tea.MouseButtonRight, Action: tea.MouseActionPress})
+				got := updated.(Model)
+				if got.mode != modeMenu || got.menuSpace != nil {
+					t.Fatalf("collapsed=%v multipleTabs=%v row=%d: expected scoped menu, got space %p", collapsed, multipleTabs, rowIndex, got.menuSpace)
+				}
+				if multipleTabs && row.pane == 0 {
+					if got.menuTab != targetTab {
+						t.Fatal("combined row did not target tab")
+					}
+				} else if got.menuPane != target {
+					t.Fatal("pane row did not target pane")
+				}
+				if got.selected != 1 || owner.active != 0 || got.paneAttention[target.id] || !got.paneAttention[previous.id] {
+					t.Fatal("context menu did not focus and acknowledge only its target")
+				}
+			}
+		}
+	}
+}
+
+func TestSidebarContextNonTargetsDoNotChangeFocus(t *testing.T) {
+	model := newTestModel(t.TempDir(), t.TempDir())
+	for rowIndex, row := range model.sidebarRows() {
+		if row.kind == "space" || row.kind == "pane" {
+			continue
+		}
+		model.selected = 1
+		target := model.spaces[1].tab().panes[0]
+		model.paneAttention[target.id] = true
+		updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: rowIndex + 1, Button: tea.MouseButtonRight, Action: tea.MouseActionPress})
+		got := updated.(Model)
+		if got.selected != 1 || got.mode != modeTerminal || !got.paneAttention[target.id] {
+			t.Fatalf("right-clicking %q row changed focus or attention", row.kind)
+		}
+	}
+}
+
+func TestSidebarPaneContextClosesOnlyPane(t *testing.T) {
+	model := newTestModel(t.TempDir())
+	owner := model.spaces[0]
+	first := owner.tab().panes[0]
+	extra := &pane{id: model.nextID, kind: "shell"}
+	model.nextID++
+	owner.tab().panes = append(owner.tab().panes, extra)
+	owner.tab().layout = fallbackLayout(owner.tab().panes)
+	updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: 6, Button: tea.MouseButtonRight, Action: tea.MouseActionPress})
+	got := updated.(Model)
+	if got.menuPane != extra || got.menuSpace != nil {
+		t.Fatal("split pane row opened wrong menu")
+	}
+	updated, _ = got.runMenuAction("close")
+	got = updated.(Model)
+	if len(got.spaces) != 1 || len(owner.tabs) != 1 || len(owner.tab().panes) != 1 || owner.tab().panes[0] != first {
+		t.Fatal("closing split pane removed unrelated content")
+	}
+	if !layoutComplete(owner.tab().layout, owner.tab().panes) {
+		t.Fatal("invalid remaining layout")
+	}
+	// A singleton pane must not expose workspace close or last-pane close.
+	updated, _ = got.updateMouse(tea.MouseMsg{X: 3, Y: 5, Button: tea.MouseButtonRight, Action: tea.MouseActionPress})
+	got = updated.(Model)
+	for _, item := range got.menuItems() {
+		if item.action == "space-close" || item.action == "close" {
+			t.Fatal("singleton pane exposes destructive close")
+		}
+	}
+}
+
+func TestSidebarTabClosePersistsRemainingTab(t *testing.T) {
+	for _, active := range []int{0, 1} {
+		model := newTestModel(t.TempDir(), t.TempDir())
+		owner := model.spaces[1]
+		model.addTab(owner, "shell")
+		owner.active = active
+		remaining := owner.tabs[1-active]
+		model.selected = 0
+		for rowIndex, row := range model.sidebarRows() {
+			if row.kind != "pane" || row.space != 1 || row.tab != active {
+				continue
+			}
+			updated, _ := model.updateMouse(tea.MouseMsg{X: 3, Y: rowIndex + 1, Button: tea.MouseButtonRight, Action: tea.MouseActionPress})
+			model = updated.(Model)
+			break
+		}
+		updated, _ := model.runMenuAction("tab-close")
+		model = updated.(Model)
+		if len(model.spaces) != 2 || len(owner.tabs) != 1 || owner.active != 0 || owner.tabs[0] != remaining {
+			t.Fatal("tab close damaged workspace or remaining tab")
+		}
+		restored := New(Config{}, nil, "", state.State{})
+		restored.restore(model.snapshot())
+		if len(restored.spaces) != 2 || len(restored.spaces[1].tabs) != 1 || restored.spaces[1].active != 0 {
+			t.Fatal("remaining tab did not survive snapshot/restore")
+		}
+		model.openTabMenu(remaining, rect{})
+		for _, item := range model.menuItems() {
+			if item.action == "tab-close" {
+				t.Fatal("final tab offers close")
+			}
+		}
+		model.runMenuAction("tab-close")
+		if len(owner.tabs) != 1 {
+			t.Fatal("final tab was removed")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #24 by routing sidebar tab rows to the tab context menu instead of the workspace context menu. Workspace rows continue to use workspace-level close behavior.

## Changes

- Mark the first pane row for each multi-tab workspace as a tab row for context-menu routing.
- Open the tab-specific context menu for those rows and preserve active-tab selection.
- Add regression coverage for sidebar tab closure and workspace closure.

## Checks

- `gofmt -w internal/ui/model.go internal/ui/model_test.go`
- `go test ./...`
- `go vet ./...`
- `git diff --check`